### PR TITLE
Add support for HAL-FORMS property options

### DIFF
--- a/packages/hal-forms/src/_shape.ts
+++ b/packages/hal-forms/src/_shape.ts
@@ -1,4 +1,4 @@
-import type { HalObjectShape } from "@contentgrid/hal/shape";
+import type { HalObjectShape, LinkShape } from "@contentgrid/hal/shape";
 import type { TypedRequestSpec } from "@contentgrid/typed-fetch";
 
 declare const _requestType: unique symbol;
@@ -21,20 +21,26 @@ export enum HalFormsPropertyType {
     radio = "radio"
 }
 
-export interface HalFormsPropertyShape {
+export interface HalFormsPropertyShape<OptionType = any> {
     readonly name: string;
     readonly type?: `${HalFormsPropertyType}` | `${HalFormsPropertyType}[]`;
     readonly required?: boolean;
     readonly readOnly?: boolean;
-    readonly options?: HalFormsPropertyOptionsShape;
+    readonly options?: HalFormsPropertyOptionsShape<OptionType>;
     readonly regex?: string;
     readonly minLength?: number;
     readonly maxLength?: number;
     readonly prompt?: string;
 }
 
-interface HalFormsPropertyOptionsShape {
-    readonly inline?: string[]
+export interface HalFormsPropertyOptionsShape<T = unknown> {
+    readonly inline?: readonly T[]
+    readonly link?: LinkShape;
+    readonly selectedValues?: readonly string[];
+    readonly promptField?: keyof T & string;
+    readonly valueField?: keyof T & string;
+    readonly maxItems?: number;
+    readonly minItems?: number;
 }
 
 export type HalObjectWithTemplateShape<T, Name extends string, BodyType, ResponseType> = HalObjectShape<T> &

--- a/packages/hal-forms/src/api.ts
+++ b/packages/hal-forms/src/api.ts
@@ -1,21 +1,41 @@
+import { SimpleLink } from "@contentgrid/hal";
 import { TypedRequestSpec } from "@contentgrid/typed-fetch";
 
 export interface HalFormsTemplate<RequestSpec extends TypedRequestSpec<any, any>> {
+    readonly name: string;
     readonly request: RequestSpec;
     readonly properties: readonly HalFormsProperty[];
     property(propertyName: string): HalFormsProperty;
 }
 
-export interface HalFormsProperty {
+export interface HalFormsProperty<OptionType = unknown> {
     readonly name: string;
     readonly readOnly: boolean;
     readonly required: boolean;
     readonly type: string | undefined;
-    readonly options: ReadonlyArray<HalFormsPropertyOption>;
+    readonly options: HalFormsPropertyInlineOptions<OptionType> | HalFormsPropertyRemoteOptions<OptionType>;
     readonly regex: RegExp;
     readonly minLength: number;
     readonly maxLength: number;
     readonly prompt: string | undefined;
+}
+
+interface HalFormsPropertyCommonOptions<T> {
+    readonly selectedValues: readonly string[];
+    readonly maxItems: number;
+    readonly minItems: number;
+    toOption(data: T): HalFormsPropertyOption;
+    loadOptions(fetcher: (link: SimpleLink) => Promise<readonly T[]>): Promise<readonly HalFormsPropertyOption[]>
+    isInline(): this is HalFormsPropertyInlineOptions<T>;
+    isRemote(): this is HalFormsPropertyRemoteOptions<T>;
+}
+
+export interface HalFormsPropertyInlineOptions<T = unknown> extends HalFormsPropertyCommonOptions<T> {
+    readonly inline: ReadonlyArray<T>;
+}
+
+export interface HalFormsPropertyRemoteOptions<T = unknown> extends HalFormsPropertyCommonOptions<T> {
+    readonly link: SimpleLink;
 }
 
 export interface HalFormsPropertyOption {

--- a/packages/hal-forms/src/errors.ts
+++ b/packages/hal-forms/src/errors.ts
@@ -1,4 +1,5 @@
 import { HalError } from "@contentgrid/hal";
+import { HalFormsProperty, HalFormsTemplate } from "./api";
 
 export class HalFormsTemplateError extends HalError {
     public constructor(readonly template: string, message: string) {
@@ -13,5 +14,13 @@ export class HalTemplateNotFoundError extends HalFormsTemplateError {
         super(template, "was not found");
         Object.setPrototypeOf(this, new.target.prototype);
         this.name = HalTemplateNotFoundError.name;
+    }
+}
+
+export class InvalidHalFormsOptionError extends HalFormsTemplateError {
+    public constructor(template: HalFormsTemplate<any>, readonly property: HalFormsProperty, message: string) {
+        super(template.name, `property ${property.name} has invalid options: ${message}`)
+        Object.setPrototypeOf(this, new.target.prototype);
+        this.name = InvalidHalFormsOptionError.name;
     }
 }

--- a/packages/hal/src/Link.ts
+++ b/packages/hal/src/Link.ts
@@ -1,12 +1,11 @@
 import UriTemplate from "@contentgrid/uri-template";
 import LinkRelation from "./rels/LinkRelation";
 
-export default class Link {
+export class SimpleLink {
     // @internal
     #deprecationWarned: boolean = false;
 
-    // @internal
-    public constructor(public readonly rel: LinkRelation, private readonly data: LinkShape) {
+    public constructor(private readonly data: LinkShape) {
 
     }
 
@@ -52,6 +51,22 @@ export default class Link {
     }
 
     public toString() {
+        return `<${this.href}>; ${toLinkParams({
+            name: this.name,
+            title: this.title,
+            type: this.type
+        })}`
+    }
+
+}
+
+export default class Link extends SimpleLink {
+    // @internal
+    public constructor(public readonly rel: LinkRelation, data: LinkShape) {
+        super(data);
+    }
+
+    public override toString() {
         return `<${this.href}>; ${toLinkParams({
             rel: this.rel.value,
             name: this.name,

--- a/packages/hal/src/index.ts
+++ b/packages/hal/src/index.ts
@@ -2,5 +2,5 @@ export { default as HalObject } from "./HalObject";
 export { default as HalError } from "./HalError";
 export { default as HalEmbedded } from "./HalEmbedded";
 export { default as HalSlice } from "./HalSlice";
-export { default as Link } from "./Link";
+export { default as Link, SimpleLink } from "./Link";
 export { default as Links } from "./Links";


### PR DESCRIPTION
Previously, only support for getting inline options was available;
this is now extended to external options, as well as the options for
`maxItems`/`minItems`, `promptField`/`valueField` and `selectedValues`
