### PR TITLE
HAL-FORMS value manager and request encoder

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "ES6",                                /* Specify what module code is generated. */
     "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node16",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "Bundler",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */

--- a/packages/hal-forms/README.md
+++ b/packages/hal-forms/README.md
@@ -77,6 +77,34 @@ templateValues.values.forEach(value => {
 
 </details>
 
+### Encoding HAL-FORMS into requests
+
+After collecting user input, you probably want to send a request to the backend to submit the values entered in the form.
+
+The `@contentgrid/hal-forms/codecs` sub-package encodes the values according to the content-type required by the HAL-FORMS template.
+
+<details>
+
+<summary>Code example for encoding form values with codecs</summary>
+
+```typescript
+import codecs from "@contentgrid/hal-forms/codecs";
+
+const request = codecs.requireCodecFor(template) // template is a HalFormsTemplate
+    .encode(templateValues); // templateValues is a HalFormValues
+
+// The HAL-FORMS template method, target, contentType and values are encoded in request
+
+// Put some additional headers on your request here
+request.headers.set('Authorization', 'Basic ....');
+
+// Perform the HTTP request
+const response = await fetch(request);
+console.log(response);
+```
+
+</details>
+
 ### Shapes
 
 The `@contentgrid/hal-forms/shape` sub-package provides POJO (plain old javascript object) types that can be used to represent the raw HAL-FORMS JSON data.

--- a/packages/hal-forms/README.md
+++ b/packages/hal-forms/README.md
@@ -47,6 +47,36 @@ template.properties.forEach(property => {
 
 </details>
 
+### Interactive form value management
+
+When you have a form, you probably want to display it to your users in some way so they can enter values in your form fields.
+
+The `@contentgrid/hal-forms/values` package is a simple utility to manage the form field values entered by users.
+
+It uses the correct datatype belonging to each form field.
+
+<details>
+
+<summary>Code example for form value management using HAL-FORMS values</summary>
+
+```typescript
+import { createValues } from "@contentgrid/hal-forms/values"
+
+const templateValues = createValues(template); // template is a HalFormsTemplate
+
+templateValues.values.forEach(value => {
+    console.log(`Field ${value.property.name}: ${value.value}`)
+})
+
+templateValues = templateValues.withValue("name", "Jeff"); // Creates a new object with the value set
+
+templateValues.values.forEach(value => {
+    console.log(`Field ${value.property.name}: ${value.value}`)
+})
+```
+
+</details>
+
 ### Shapes
 
 The `@contentgrid/hal-forms/shape` sub-package provides POJO (plain old javascript object) types that can be used to represent the raw HAL-FORMS JSON data.

--- a/packages/hal-forms/__tests__/codecs.ts
+++ b/packages/hal-forms/__tests__/codecs.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "@jest/globals";
+import buildTemplate from "../src/builder";
+import { default as codecs, Encoders, HalFormsCodecNotAvailableError, HalFormsCodecs } from "../src/codecs";
+import { createValues } from "../src/values";
+
+const form = buildTemplate("POST", "http://localhost/invoices")
+    .withContentType("application/json")
+    .addProperty("created_at", b => b
+        .withType("datetime")
+        .withRequired(true)
+    )
+    .addProperty("total.net", b => b
+        .withType("number")
+    )
+    .addProperty("total.vat", b => b
+        .withType("number")
+    )
+    .addProperty("senders", b => b.withType("url")
+        .withOptions(b => b.withMinItems(0))
+    )
+    .addProperty("name", b => b.withValue("Jefke"));
+
+describe("HalFormsCodecs", () => {
+
+    describe("#findCodecFor()", () => {
+        test("finds a codec", () => {
+            const c = codecs.findCodecFor(form);
+            expect(c).not.toBeNull();
+        })
+
+        test("does not find a codec", () => {
+            const empty = HalFormsCodecs.builder()
+                .registerEncoder("example/json", Encoders.json())
+                .build();
+            const c = empty.findCodecFor(form);
+            expect(c).toBeNull();
+        })
+    });
+
+    describe("#requireCodecFor()", () => {
+
+        test("requires a codec", () => {
+            const c = codecs.requireCodecFor(form);
+            expect(c).not.toBeNull();
+        })
+
+        test("does not find a required codec", () => {
+            const empty = HalFormsCodecs.builder().build();
+            expect(() => empty.requireCodecFor(form))
+                .toThrowError(new HalFormsCodecNotAvailableError(form));
+        })
+
+    })
+})
+
+describe("Encoders.json()", () => {
+    const values = createValues(form);
+    const codecs = HalFormsCodecs.builder()
+        .registerEncoder("application/json", Encoders.json())
+        .build();
+
+    test("Encodes default values", () => {
+        const encoded = codecs.requireCodecFor(form).encode(values.values);
+
+        expect(encoded).toBeInstanceOf(Request);
+
+        expect(encoded.json())
+            .resolves
+            .toEqual({
+                "name": "Jefke"
+            });
+    })
+
+    test("Encodes nested values as flat JSON", () => {
+
+        const encoded = codecs.requireCodecFor(form).encode(
+            values
+                .withValue("total.net", 123)
+                .withValue("total.vat", 456)
+                .values
+        );
+
+        expect(encoded).toBeInstanceOf(Request);
+
+        expect(encoded.json())
+            .resolves
+            .toEqual({
+                "name": "Jefke",
+                "total.net": 123,
+                "total.vat": 456
+            })
+    });
+
+})
+
+describe("Encoders.nestedJson()", () => {
+    const values = createValues(form);
+    const codecs = HalFormsCodecs.builder()
+        .registerEncoder("application/json", Encoders.nestedJson())
+        .build();
+
+    test("Encodes default values", () => {
+        const encoded = codecs.requireCodecFor(form).encode(values.values);
+
+        expect(encoded).toBeInstanceOf(Request);
+
+        expect(encoded.json())
+            .resolves
+            .toEqual({
+                "name": "Jefke"
+            });
+    })
+
+    test("Encodes nested values as flat JSON", () => {
+
+        const encoded = codecs.requireCodecFor(form).encode(
+            values
+                .withValue("total.net", 123)
+                .withValue("total.vat", 456)
+                .values
+        );
+
+        expect(encoded).toBeInstanceOf(Request);
+
+        expect(encoded.json())
+            .resolves
+            .toEqual({
+                "name": "Jefke",
+                "total": {
+                    "net": 123,
+                    "vat": 456
+                }
+            })
+    });
+
+})

--- a/packages/hal-forms/__tests__/model.ts
+++ b/packages/hal-forms/__tests__/model.ts
@@ -19,6 +19,7 @@ describe("resolveTemplate", () => {
         _templates: {
             ["create-form"]: {
                 method: "GET",
+                title: "Create new",
                 target: "http://localhost/create",
                 properties: [
                     {
@@ -56,6 +57,7 @@ describe("resolveTemplate", () => {
             },
             other: {
                 method: "POST",
+                contentType: "application/x-www-form-urlencoded",
                 properties: [
                     {
                         name: "ZZZ",
@@ -73,6 +75,8 @@ describe("resolveTemplate", () => {
             method: "GET",
             url: "http://localhost/create"
         })
+        expect(template?.contentType).toEqual("application/json");
+        expect(template?.title).toEqual("Create new");
         expect(template?.properties.length).toEqual(3);
         const propAbc = template!.property("abc");
         expect(template?.property("abc").readOnly).toBe(false);
@@ -135,6 +139,8 @@ describe("resolveTemplate", () => {
             method: "POST",
             url: "http://localhost/item/4"
         })
+        expect(template?.title).toBeUndefined();
+        expect(template?.contentType).toEqual("application/x-www-form-urlencoded")
         expect(template?.properties.length).toEqual(1);
         expect(template?.property("ZZZ").required).toBe(true);
     })

--- a/packages/hal-forms/__tests__/model.ts
+++ b/packages/hal-forms/__tests__/model.ts
@@ -82,8 +82,8 @@ describe("resolveTemplate", () => {
         expect(template?.property("abc").readOnly).toBe(false);
         expect(template?.property("abc").type).toEqual("text");
         const abcOpts = propAbc.options;
-        expect(abcOpts.isInline()).toBe(true);
-        expect(abcOpts.loadOptions(() => { throw new Error("Not implemented") }))
+        expect(abcOpts!.isInline()).toBe(true);
+        expect(abcOpts!.loadOptions(() => { throw new Error("Not implemented") }))
             .resolves
             .toEqual([
                 {
@@ -96,18 +96,18 @@ describe("resolveTemplate", () => {
                 }
             ])
 
-        if(abcOpts.isInline()) {
+        if(abcOpts!.isInline()) {
             expect(abcOpts.inline.length).toBe(2);
         }
 
         expect(template?.property("def").readOnly).toBe(false);
         expect(template?.property("def").type).toBe("number");
         const defOpts = template!.property("def").options;
-        expect(defOpts.isRemote()).toBe(true);
+        expect(defOpts!.isRemote()).toBe(true);
 
         const mockLoad = jest.fn(() => Promise.resolve(["1", "2", "3"]));
 
-        expect(defOpts.loadOptions(mockLoad))
+        expect(defOpts!.loadOptions(mockLoad))
             .resolves
             .toEqual([
                 {
@@ -124,7 +124,7 @@ describe("resolveTemplate", () => {
                 }
             ]);
 
-        if(abcOpts.isRemote()) {
+        if(abcOpts!.isRemote()) {
             expect(mockLoad.mock.lastCall).toHaveBeenCalledWith(abcOpts.link);
             expect(abcOpts.link.href).toEqual("http://localhost/numbers?q=4");
         }

--- a/packages/hal-forms/__tests__/values.ts
+++ b/packages/hal-forms/__tests__/values.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect } from "@jest/globals";
+import buildTemplate from "../src/builder";
+import { HalFormValueTypeError, createValues } from "../src/values";
+
+class File extends Blob {
+
+    public constructor(fileBits: BlobPart[], public name: string, private options?: FilePropertyBag) {
+        super(fileBits, options);
+    }
+
+    get lastModified(): number {
+        return this.options?.lastModified ?? 0;
+    }
+
+    get webkitRelativePath(): string {
+        return this.name;
+    }
+}
+
+global.File = File;
+
+describe("values", () => {
+
+    const form = buildTemplate("POST", "/invoices")
+        .withContentType("application/json")
+        .addProperty("created_at", b => b
+            .withType("datetime")
+            .withRequired(true)
+        )
+        .addProperty("total.net", b => b
+            .withType("number")
+        )
+        .addProperty("total.vat", b => b
+            .withType("number")
+        )
+        .addProperty("senders", b => b.withType("url")
+            .withOptions(b => b.withMinItems(0))
+        )
+        .addProperty("name", b => b.withValue("Jefke"))
+        .addProperty("picture", b => b.withType("file"))
+        .addProperty("enabled", b => b.withType("checkbox"))
+
+    const formValues = createValues(form)
+
+    test("Form defaults", () => {
+        expect(formValues.values).toHaveLength(7)
+        expect(formValues.value("created_at").value).toBeUndefined();
+        expect(formValues.value("total.net").value).toBeUndefined();
+        expect(formValues.value("total.vat").value).toBeUndefined();
+        expect(formValues.value("name").value).toEqual("Jefke");
+        expect(formValues.value("enabled").value).toBeUndefined();
+    })
+
+    describe("#withValue()", () => {
+        test("with valid values", () => {
+            const withNewData = formValues.withValue("total.vat", 123);
+
+            expect(withNewData.values).toHaveLength(7)
+            expect(withNewData.value("created_at").value).toBeUndefined();
+            expect(withNewData.value("total.net").value).toBeUndefined();
+            expect(withNewData.value("total.vat").value).toEqual(123);
+            expect(withNewData.value("name").value).toEqual("Jefke");
+            expect(withNewData.value("file").value).toBeUndefined()
+            expect(withNewData.value("enabled").value).toBeUndefined();
+        })
+
+
+        test("with a valid file", () => {
+            const file = new File([], "my-file.txt", {
+                type: "text/plain"
+            });
+            const withNewData = formValues.withValue("picture", file);
+
+            expect(withNewData.value("picture").value).toEqual(file);
+        })
+
+        test("with an invalid value type", () => {
+            expect(() => formValues.withValue("total.vat", "123"))
+                .toThrowError(new HalFormValueTypeError(form, form.property("total.vat"), "123"))
+
+            expect(() => formValues.withValue("total.vat", false))
+                .toThrowError(new HalFormValueTypeError(form, form.property("total.vat"), false))
+
+            expect(() => formValues.withValue("created_at", false))
+                .toThrowError(new HalFormValueTypeError(form, form.property("created_at"), false))
+
+            const dateArray = [new Date(), new Date()];
+            expect(() => formValues.withValue("created_at", dateArray))
+                .toThrowError(new HalFormValueTypeError(form, form.property("created_at"), dateArray))
+
+            expect(() => formValues.withValue("senders", "/sender/123"))
+                .toThrowError(new HalFormValueTypeError(form, form.property("senders"), "/sender/123"))
+
+            expect(() => formValues.withValue("senders", [["/abc"] as any]))
+                .toThrowError(new HalFormValueTypeError(form, form.property("senders"), [["/abc"]]))
+
+            expect(() => formValues.withValue("senders", dateArray))
+                .toThrowError(new HalFormValueTypeError(form, form.property("senders"), dateArray))
+
+            expect(() => formValues.withValue("picture", "abc"))
+                .toThrowError(new HalFormValueTypeError(form, form.property("picture"), "abc"))
+
+            expect(() => formValues.withValue("enabled", "xyz"))
+                .toThrowError(new HalFormValueTypeError(form, form.property("enabled"), "xyz"))
+
+        })
+
+        test("with a stringy date value", () => {
+            const date = "2024-03-07T18:16:12+01:00";
+            const withNewData = formValues.withValue("created_at", date);
+            expect(withNewData.value("created_at").value).toBeInstanceOf(Date);
+        })
+
+        test("with an array value", () => {
+            const senders = [
+                "/senders/1",
+                "/senders/2"
+            ];
+            const withNewData = formValues.withValue("senders", senders);
+            expect(withNewData.value("senders").value).toEqual(senders);
+        })
+
+        test("with a boolean value", () => {
+            const withNewData = formValues.withValue("enabled", false);
+            expect(withNewData.value("enabled").value).toEqual(false);
+        })
+    })
+
+    describe("#withoutValue()", () => {
+        test("with a null value", () => {
+            const withNewData = formValues.withValue("total.vat", 123)
+                .withoutValue("total.vat");
+            expect(withNewData.value("total.vat").value).toEqual(undefined);
+        })
+    })
+
+    describe("#withValues()", () => {
+        test("with correct values", () => {
+            const withNewData = formValues.withValues({
+                "created_at": new Date(),
+                "total.net": 120,
+                "name": "Jaak"
+            });
+
+            expect(withNewData.values).toHaveLength(7)
+            expect(withNewData.value("created_at").value).toBeInstanceOf(Date);
+            expect(withNewData.value("total.net").value).toEqual(120);
+            expect(withNewData.value("total.vat").value).toBeUndefined();
+            expect(withNewData.value("name").value).toEqual("Jaak");
+        })
+
+    })
+
+})
+
+describe("HalFormValueTypeError", () => {
+    const form = buildTemplate("POST", "/")
+        .withName("xyz")
+        .addProperty("single", p => p)
+        .addProperty("multi", p => p.withOptions(o => o))
+        .addProperty("file", p => p.withType("file"))
+
+    const single = form.property("single");
+    const multi = form.property("multi");
+
+    describe("Exception message", () => {
+        test("for single-value field", () => {
+            const prefix = "Template xyz: property single: expected type text, but got "
+            expect(new HalFormValueTypeError(form, single, null)).toHaveProperty("message", prefix + "null")
+            expect(new HalFormValueTypeError(form, single, undefined)).toHaveProperty("message", prefix + "undefined")
+            expect(new HalFormValueTypeError(form, single, [])).toHaveProperty("message", prefix + "empty list")
+            expect(new HalFormValueTypeError(form, single, [123])).toHaveProperty("message", prefix + "list of number")
+            expect(new HalFormValueTypeError(form, single, [123, 456])).toHaveProperty("message", prefix + "list of number")
+            expect(new HalFormValueTypeError(form, single, ["abc"])).toHaveProperty("message", prefix + "list of string")
+            expect(new HalFormValueTypeError(form, single, [new Date()])).toHaveProperty("message", prefix + "list of Date")
+            expect(new HalFormValueTypeError(form, single, [[null]])).toHaveProperty("message", prefix + "list of list of null")
+            expect(new HalFormValueTypeError(form, single, [123, "string"])).toHaveProperty("message", prefix + "list of number, string")
+
+            expect(new HalFormValueTypeError(form, form.property("file"), 123))
+                .toHaveProperty("message", "Template xyz: property file: expected type file, but got number")
+            expect(new HalFormValueTypeError(form, single, new File([], "filename.txt")))
+                .toHaveProperty("message", "Template xyz: property single: expected type text, but got File")
+        })
+
+        test("for multi-value field", () => {
+            expect(new HalFormValueTypeError(form, multi, null))
+                .toHaveProperty("message", "Template xyz: property multi: expected type text list, but got null")
+        })
+
+    })
+
+})

--- a/packages/hal-forms/__tests__/values.ts
+++ b/packages/hal-forms/__tests__/values.ts
@@ -75,6 +75,10 @@ describe("values", () => {
         })
 
         test("with an invalid value type", () => {
+
+            expect(() => formValues.withValue("total.vat", null as any))
+                .toThrowError(new HalFormValueTypeError(form, form.property("total.vat"), null))
+
             expect(() => formValues.withValue("total.vat", "123"))
                 .toThrowError(new HalFormValueTypeError(form, form.property("total.vat"), "123"))
 
@@ -126,12 +130,10 @@ describe("values", () => {
         })
     })
 
-    describe("#withoutValue()", () => {
-        test("with a null value", () => {
-            const withNewData = formValues.withValue("total.vat", 123)
-                .withoutValue("total.vat");
-            expect(withNewData.value("total.vat").value).toEqual(undefined);
-        })
+    test("#withoutValue()", () => {
+        const withNewData = formValues.withValue("total.vat", 123)
+            .withoutValue("total.vat");
+        expect(withNewData.value("total.vat").value).toBeUndefined();
     })
 
     describe("#withValues()", () => {

--- a/packages/hal-forms/package.json
+++ b/packages/hal-forms/package.json
@@ -21,6 +21,11 @@
       "types": "./build/shape.d.ts",
       "import": "./build/shape.mjs",
       "default": "./build/shape.js"
+    },
+    "./values": {
+      "types": "./build/values/index.d.ts",
+      "import": "./build/values/index.mjs",
+      "default": "./build/values/index.js"
     }
   },
   "license": "MIT",

--- a/packages/hal-forms/package.json
+++ b/packages/hal-forms/package.json
@@ -26,6 +26,16 @@
       "types": "./build/values/index.d.ts",
       "import": "./build/values/index.mjs",
       "default": "./build/values/index.js"
+    },
+    "./codecs": {
+      "types": "./build/codecs/index.d.ts",
+      "import": "./build/codecs/index.mjs",
+      "default": "./build/codecs/index.js"
+    },
+    "./codecs/encoders": {
+      "types": "./build/codecs/encoders/index.d.ts",
+      "import": "./build/codecs/encoders/index.mjs",
+      "default": "./build/codecs/encoders/index.js"
     }
   },
   "license": "MIT",

--- a/packages/hal-forms/src/_shape.ts
+++ b/packages/hal-forms/src/_shape.ts
@@ -18,14 +18,23 @@ export enum HalFormsPropertyType {
     hidden = "hidden",
     text = "text",
     url = "url",
+    email = "email",
+    date = "date",
+    time = "time",
+    datetime = "datetime",
+    datetime_local = "datetime-local",
     number = "number",
+    range = "range",
     checkbox = "checkbox",
-    radio = "radio"
+    radio = "radio",
+    file = "file",
 }
+
+export type HalFormsPropertyValue = string | number | boolean | null | readonly string[] | readonly number[] | readonly boolean[];
 
 export interface HalFormsPropertyShape<OptionType = any> {
     readonly name: string;
-    readonly type?: `${HalFormsPropertyType}` | `${HalFormsPropertyType}[]`;
+    readonly type?: `${HalFormsPropertyType}`;
     readonly required?: boolean;
     readonly readOnly?: boolean;
     readonly options?: HalFormsPropertyOptionsShape<OptionType>;
@@ -33,6 +42,7 @@ export interface HalFormsPropertyShape<OptionType = any> {
     readonly minLength?: number;
     readonly maxLength?: number;
     readonly prompt?: string;
+    readonly value?: HalFormsPropertyValue;
 }
 
 export interface HalFormsPropertyOptionsShape<T = unknown> {

--- a/packages/hal-forms/src/_shape.ts
+++ b/packages/hal-forms/src/_shape.ts
@@ -6,6 +6,8 @@ declare const _requestType: unique symbol;
 export interface HalFormsTemplateShape<BodyType = unknown, ResponseType = unknown> {
     readonly method: string;
     readonly target?: string;
+    readonly contentType?: string;
+    readonly title?: string;
     readonly properties: readonly HalFormsPropertyShape[];
     readonly [_requestType]?: TypedRequestSpec<BodyType, ResponseType>;
 }

--- a/packages/hal-forms/src/api.ts
+++ b/packages/hal-forms/src/api.ts
@@ -3,6 +3,8 @@ import { TypedRequestSpec } from "@contentgrid/typed-fetch";
 
 export interface HalFormsTemplate<RequestSpec extends TypedRequestSpec<any, any>> {
     readonly name: string;
+    readonly title: string | undefined;
+    readonly contentType: string;
     readonly request: RequestSpec;
     readonly properties: readonly HalFormsProperty[];
     property(propertyName: string): HalFormsProperty;

--- a/packages/hal-forms/src/api.ts
+++ b/packages/hal-forms/src/api.ts
@@ -1,5 +1,6 @@
 import { SimpleLink } from "@contentgrid/hal";
 import { TypedRequestSpec } from "@contentgrid/typed-fetch";
+import { HalFormsPropertyType, HalFormsPropertyValue } from "./_shape";
 
 export interface HalFormsTemplate<RequestSpec extends TypedRequestSpec<any, any>> {
     readonly name: string;
@@ -14,12 +15,14 @@ export interface HalFormsProperty<OptionType = unknown> {
     readonly name: string;
     readonly readOnly: boolean;
     readonly required: boolean;
-    readonly type: string;
-    readonly options: HalFormsPropertyInlineOptions<OptionType> | HalFormsPropertyRemoteOptions<OptionType>;
+    readonly type: HalFormsPropertyType | string;
+    readonly options: HalFormsPropertyInlineOptions<OptionType> | HalFormsPropertyRemoteOptions<OptionType> | null;
+    readonly multiValue: boolean;
     readonly regex: RegExp;
     readonly minLength: number;
     readonly maxLength: number;
     readonly prompt: string | undefined;
+    readonly value: HalFormsPropertyValue | undefined;
 }
 
 interface HalFormsPropertyCommonOptions<T> {

--- a/packages/hal-forms/src/api.ts
+++ b/packages/hal-forms/src/api.ts
@@ -14,7 +14,7 @@ export interface HalFormsProperty<OptionType = unknown> {
     readonly name: string;
     readonly readOnly: boolean;
     readonly required: boolean;
-    readonly type: string | undefined;
+    readonly type: string;
     readonly options: HalFormsPropertyInlineOptions<OptionType> | HalFormsPropertyRemoteOptions<OptionType>;
     readonly regex: RegExp;
     readonly minLength: number;

--- a/packages/hal-forms/src/builder.ts
+++ b/packages/hal-forms/src/builder.ts
@@ -1,6 +1,7 @@
 import { HalFormsProperty, HalFormsPropertyInlineOptions, HalFormsPropertyOption, HalFormsPropertyRemoteOptions, HalFormsTemplate } from "./api";
 import { MATCH_ANYTHING, MATCH_NOTHING } from "./_internal";
 import { TypedRequestSpec } from "@contentgrid/typed-fetch";
+import { HalFormsPropertyType, HalFormsPropertyValue } from "./_shape";
 
 export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate<TypedRequestSpec<Body, Response>> {
 
@@ -21,17 +22,22 @@ export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate
         return undefined;
     }
 
+    public withName(name: string): HalFormsTemplateBuilder<Body, Response> {
+        return new HalFormsTemplateBuilder(name, this.request, this.contentType, this.properties);
+    }
+
     public property(propertyName: string): HalFormsProperty {
         return this.properties
             .find(property => property.name === propertyName) ?? new HalFormsPropertyBuilder(
                 propertyName,
-                "text",
+                HalFormsPropertyType.text,
                 true,
                 false,
-                [],
+                null,
                 MATCH_NOTHING,
                 0,
                 Number.MAX_SAFE_INTEGER,
+                undefined,
                 undefined
             );
     }
@@ -40,13 +46,14 @@ export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate
 
         const newPropertyBuilder = new HalFormsPropertyBuilder(
             propertyName,
-            "text",
+            HalFormsPropertyType.text,
             false,
             false,
-            [],
+            null,
             MATCH_ANYTHING,
             0,
             Number.MAX_SAFE_INTEGER,
+            undefined,
             undefined
         );
 
@@ -68,32 +75,53 @@ export class HalFormsPropertyBuilder implements HalFormsProperty {
         public readonly type: string,
         public readonly readOnly: boolean,
         public readonly required: boolean,
-        private readonly _options: readonly HalFormsPropertyOption[],
+        private readonly _options: HalFormsPropertyOptionsBuilder | null,
         public readonly regex: RegExp,
         public readonly minLength: number,
         public readonly maxLength: number,
         public readonly prompt: string | undefined,
+        public readonly value: HalFormsPropertyValue | undefined
     ) {
     }
 
-    public get options(): HalFormsPropertyInlineOptions<HalFormsPropertyOption> {
-        return new HalFormsPropertyInlineOptionsImpl(this._options);
+    public get options(): HalFormsPropertyInlineOptions | HalFormsPropertyRemoteOptions | null {
+        if(this._options === null) {
+            return null;
+        }
+        return this._options.build();
     }
 
+    public get multiValue(): boolean {
+        if (this.options === null) {
+            return false;
+        }
+        return this.options.maxItems !== 1;
+    }
+
+
     public withType(type: string): HalFormsPropertyBuilder {
-        return new HalFormsPropertyBuilder(this.name, type, this.readOnly, this.required, this._options, this.regex, this.minLength, this.maxLength, this.prompt);
+        return new HalFormsPropertyBuilder(this.name, type, this.readOnly, this.required, this._options, this.regex, this.minLength, this.maxLength, this.prompt, this.value);
     }
 
     public withReadOnly(readOnly: boolean): HalFormsPropertyBuilder {
-        return new HalFormsPropertyBuilder(this.name, this.type, readOnly, this.required, this._options, this.regex, this.minLength, this.maxLength, this.prompt);
+        return new HalFormsPropertyBuilder(this.name, this.type, readOnly, this.required, this._options, this.regex, this.minLength, this.maxLength, this.prompt, this.value);
     }
 
     public withRequired(required: boolean): HalFormsPropertyBuilder {
-        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, required, this._options, this.regex, this.minLength, this.maxLength, this.prompt);
+        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, required, this._options, this.regex, this.minLength, this.maxLength, this.prompt, this.value);
     }
 
-    public withOptions(options: readonly HalFormsPropertyOption[]): HalFormsPropertyBuilder {
-        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, this.required, options, this.regex, this.minLength, this.maxLength, this.prompt);
+    public withOptions(options: readonly HalFormsPropertyOption[]): HalFormsPropertyBuilder;
+    public withOptions(options: (builder: HalFormsPropertyOptionsBuilder) => HalFormsPropertyOptionsBuilder): HalFormsPropertyBuilder;
+
+    public withOptions(options: readonly HalFormsPropertyOption[] | ((builder: HalFormsPropertyOptionsBuilder) => HalFormsPropertyOptionsBuilder)): HalFormsPropertyBuilder {
+        if(Array.isArray(options)) {
+            return this.withOptions(opts => opts.withInline(options));
+        }
+        if(typeof options === "function") {
+            return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, this.required, options(this._options ?? new HalFormsPropertyInlineOptionsImpl([])), this.regex, this.minLength, this.maxLength, this.prompt, this.value);
+        }
+        throw new Error("Unknown type of options");
     }
 
     public addOption(option: HalFormsPropertyOption): HalFormsPropertyBuilder;
@@ -102,37 +130,66 @@ export class HalFormsPropertyBuilder implements HalFormsProperty {
     public addOption(optionOrValue: HalFormsPropertyOption|string, prompt?: string): HalFormsPropertyBuilder {
         const option = typeof optionOrValue === "object" ? optionOrValue : { value: optionOrValue, prompt: prompt ?? optionOrValue };
 
-        return this.withOptions(this._options.concat([option]))
+        return this.withOptions(o => o.addInlineOption(option))
     }
 
     public withRegex(regex: RegExp|null): HalFormsPropertyBuilder {
-        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, this.required, this._options, regex ?? MATCH_ANYTHING, this.minLength, this.maxLength, this.prompt);
+        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, this.required, this._options, regex ?? MATCH_ANYTHING, this.minLength, this.maxLength, this.prompt, this.value);
     }
 
     public withLength(min: number, max: number) {
-        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, this.required, this._options, this.regex, min, max, this.prompt);
+        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, this.required, this._options, this.regex, min, max, this.prompt, this.value);
     }
 
     public withPrompt(prompt: string): HalFormsPropertyBuilder {
-        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, this.required, this._options, this.regex, this.minLength, this.maxLength, prompt);
+        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, this.required, this._options, this.regex, this.minLength, this.maxLength, prompt, this.value);
+    }
+
+    public withValue(value: HalFormsPropertyValue | undefined) {
+        return new HalFormsPropertyBuilder(this.name, this.type, this.readOnly, this.required, this._options, this.regex, this.minLength, this.maxLength, this.prompt, value);
     }
 }
 
-class HalFormsPropertyInlineOptionsImpl implements HalFormsPropertyInlineOptions<HalFormsPropertyOption> {
-    public constructor(public readonly inline: readonly HalFormsPropertyOption[]) {
+export interface HalFormsPropertyOptionsBuilder {
+    withInline(inline: readonly HalFormsPropertyOption[]): HalFormsPropertyOptionsBuilder;
+    addInlineOption(option: HalFormsPropertyOption): HalFormsPropertyOptionsBuilder;
+    withMaxItems(maxItems: number): HalFormsPropertyOptionsBuilder;
+    withMinItems(minItems: number): HalFormsPropertyOptionsBuilder;
+    build(): HalFormsPropertyInlineOptions | HalFormsPropertyRemoteOptions;
+}
 
+class HalFormsPropertyInlineOptionsImpl implements HalFormsPropertyInlineOptions<HalFormsPropertyOption>, HalFormsPropertyOptionsBuilder {
+
+    public constructor(
+        public readonly inline: readonly HalFormsPropertyOption[],
+        public readonly maxItems: number = Infinity,
+        public readonly minItems: number = 0,
+    ) {
+
+    }
+
+    public withInline(inline: readonly HalFormsPropertyOption[]): HalFormsPropertyOptionsBuilder {
+        return new HalFormsPropertyInlineOptionsImpl(inline, this.maxItems, this.minItems);
+    }
+
+    public addInlineOption(option: HalFormsPropertyOption): HalFormsPropertyOptionsBuilder {
+        return this.withInline(this.inline.concat([option]));
+    }
+
+    public withMaxItems(maxItems: number): HalFormsPropertyOptionsBuilder {
+        return new HalFormsPropertyInlineOptionsImpl(this.inline, maxItems, this.minItems);
+    }
+
+    public withMinItems(minItems: number): HalFormsPropertyOptionsBuilder {
+        return new HalFormsPropertyInlineOptionsImpl(this.inline, this.maxItems, minItems);
+    }
+
+    public build(): HalFormsPropertyInlineOptions<unknown> | HalFormsPropertyRemoteOptions<unknown> {
+        return this;
     }
 
     public get selectedValues(): readonly string[] {
         return[]
-    }
-
-    public get maxItems(): number {
-        return Infinity;
-    }
-
-    public get minItems(): number {
-        return 0;
     }
 
     public toOption(data: HalFormsPropertyOption): HalFormsPropertyOption {

--- a/packages/hal-forms/src/builder.ts
+++ b/packages/hal-forms/src/builder.ts
@@ -5,12 +5,21 @@ import { SimpleLink } from "@contentgrid/hal";
 
 export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate<TypedRequestSpec<Body, Response>> {
 
-    private constructor(public readonly name: string, public readonly request: TypedRequestSpec<Body, Response>, public readonly properties: HalFormsProperty[] = []) {
+    private constructor(
+        public readonly name: string,
+        public readonly request: TypedRequestSpec<Body, Response>,
+        public readonly contentType: string = "application/json",
+        public readonly properties: HalFormsProperty[] = []
+    ) {
 
     }
 
     public static from<B, R>(request: TypedRequestSpec<B, R>): HalFormsTemplateBuilder<B, R> {
         return new HalFormsTemplateBuilder(request.method + " "+request.url, request);
+    }
+
+    public get title() {
+        return undefined;
     }
 
     public property(propertyName: string): HalFormsProperty {
@@ -44,7 +53,11 @@ export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate
 
         const builtProperty = factory(newPropertyBuilder);
 
-        return new HalFormsTemplateBuilder(this.name, this.request, this.properties.concat([builtProperty]))
+        return new HalFormsTemplateBuilder(this.name, this.request, this.contentType, this.properties.concat([builtProperty]))
+    }
+
+    public withContentType(contentType: string):  HalFormsTemplateBuilder<Body, Response> {
+        return new HalFormsTemplateBuilder(this.name, this.request, contentType, this.properties)
     }
 
 }

--- a/packages/hal-forms/src/builder.ts
+++ b/packages/hal-forms/src/builder.ts
@@ -1,7 +1,6 @@
 import { HalFormsProperty, HalFormsPropertyInlineOptions, HalFormsPropertyOption, HalFormsPropertyRemoteOptions, HalFormsTemplate } from "./api";
 import { MATCH_ANYTHING, MATCH_NOTHING } from "./_internal";
 import { TypedRequestSpec } from "@contentgrid/typed-fetch";
-import { SimpleLink } from "@contentgrid/hal";
 
 export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate<TypedRequestSpec<Body, Response>> {
 
@@ -26,7 +25,7 @@ export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate
         return this.properties
             .find(property => property.name === propertyName) ?? new HalFormsPropertyBuilder(
                 propertyName,
-                undefined,
+                "text",
                 true,
                 false,
                 [],
@@ -41,7 +40,7 @@ export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate
 
         const newPropertyBuilder = new HalFormsPropertyBuilder(
             propertyName,
-            undefined,
+            "text",
             false,
             false,
             [],
@@ -63,9 +62,10 @@ export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate
 }
 
 export class HalFormsPropertyBuilder implements HalFormsProperty {
+    // @internal
     public constructor(
         public readonly name: string,
-        public readonly type: string | undefined,
+        public readonly type: string,
         public readonly readOnly: boolean,
         public readonly required: boolean,
         private readonly _options: readonly HalFormsPropertyOption[],

--- a/packages/hal-forms/src/codecs/api.ts
+++ b/packages/hal-forms/src/codecs/api.ts
@@ -1,0 +1,89 @@
+import { TypedRequest, TypedRequestSpec } from "@contentgrid/typed-fetch";
+import { HalFormsTemplate } from "../api";
+import { AnyHalFormValue } from "../values";
+import { HalFormsEncoder } from "./encoders";
+import HalFormsCodecsImpl from "./impl";
+
+/**
+ * HAL-FORMS codec
+ *
+ * A codec encodes HAL-FORMS values into a {@link TypedRequest} for sending with {@link fetch}
+ */
+export interface HalFormsCodec<T, R> {
+    /**
+     * Encode HAL-FORMS values into a request
+     * @param values - The HAL-FORMS values to encode
+     * @returns A {@link TypedRequest} that can be sent with {@link fetch}
+     */
+    encode(values: readonly AnyHalFormValue[]): TypedRequest<T, R>
+}
+
+/**
+ * Lookup for {@link HalFormsCodec}s
+ *
+ * @see {@link HalFormsCodecs.builder} to build an instance
+ */
+export interface HalFormsCodecs {
+    /**
+     * Look for a codec for a HAL-FORMS template
+     *
+     * @see {@link HalFormsCodecs#requireCodecFor} for the variant that throws an error when no codec is available
+     *
+     * @param template - The HAL-FORMS template to look up a codec for
+     * @return A codec if one is available, or null if no codec is available
+     */
+    findCodecFor<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>): HalFormsCodec<T, R> | null;
+
+    /**
+     * Require a codec for a HAL-FORMS template
+     *
+     * @see {@link HalFormsCodecs#requireCodecFor} for the variant that throws an error when no codec is available
+     *
+     * @param template - The HAL-FORMS template to look up a codec for
+     *
+     * @throws {@link ./errors#HalFormsCodecNotAvailableError} when no codec is available
+     *
+     * @return A codec
+     */
+    requireCodecFor<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>): HalFormsCodec<T, R>;
+}
+
+export namespace HalFormsCodecs {
+
+    /**
+     * @returns Create a builder for {@link HalFormsCodecs}
+     */
+    export function builder(): HalFormsCodecsBuilder {
+        return new HalFormsCodecsImpl();
+    }
+}
+
+/**
+ * Builder for {@link HalFormsCodecs}
+ */
+export interface HalFormsCodecsBuilder {
+
+    /**
+     * Registers an encoder for a content type.
+     *
+     * All HAL-FORMS templates with a certain `contentType` will be encoded using this encoder.
+     *
+     * @param contentType - The content-type to register the encoder for
+     * @param encoder - The encoder to use for the content-type
+     */
+    registerEncoder(contentType: string, encoder: HalFormsEncoder): this;
+
+    /**
+     * Registers all codecs from a {@link HalFormsCodecs}
+     *
+     * All available codecs will be used
+     *
+     * @param codecs - Codecs to register
+     */
+    registerCodecs(codecs: HalFormsCodecs): this;
+
+    /**
+     * Finish building and create the {@link HalFormsCodecs}
+     */
+    build(): HalFormsCodecs;
+}

--- a/packages/hal-forms/src/codecs/encoders/api.ts
+++ b/packages/hal-forms/src/codecs/encoders/api.ts
@@ -1,0 +1,21 @@
+import { TypedRequest, TypedRequestSpec } from "@contentgrid/typed-fetch";
+import { HalFormsTemplate } from "../../api";
+import { AnyHalFormValue } from "../../values";
+
+/**
+ * HAL-FORMS template value encoder
+ *
+ * This interface is only for implementing custom encoders.
+ *
+ * @see {@link ../api#HalFormsCodec} for encoding values
+ */
+export interface HalFormsEncoder {
+
+    /**
+     * Encode HAL-FORMS values into a request
+     *
+     * @param template - HAL-FORMS template
+     * @param values - The HAL-FORMS values to encode
+     */
+    encode<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>, values: readonly AnyHalFormValue[]): TypedRequest<T, R>;
+}

--- a/packages/hal-forms/src/codecs/encoders/index.ts
+++ b/packages/hal-forms/src/codecs/encoders/index.ts
@@ -1,0 +1,2 @@
+export type * from "./api";
+export { json, nestedJson } from "./json"

--- a/packages/hal-forms/src/codecs/encoders/json.ts
+++ b/packages/hal-forms/src/codecs/encoders/json.ts
@@ -1,0 +1,89 @@
+import { Representation, TypedRequest, TypedRequestSpec, createRequest } from "@contentgrid/typed-fetch";
+import { HalFormsProperty, HalFormsTemplate } from "../../api";
+import { AnyHalFormValue } from "../../values/api";
+import { HalFormsEncoder } from "./api";
+
+/**
+ * Encodes HAL-FORMS values as a JSON object
+ *
+ * The JSON object is created as a simple object mapping a HAL-FORMS property name to its value.
+ * Nested objects are not supported.
+ */
+export function json(): HalFormsEncoder {
+    return new JsonHalFormsEncoder(null);
+}
+
+/**
+ * Encodes HAL-FORMS values as a nested JSON object
+ *
+ * The JSON object is created as an object mapping a HAL-FORMS property name to their values.
+ * Nested objects are supported; The separator character accesses nested JSON objects.
+ *
+ * e.g. A HAL-FORM with properties `user.name`, `user.email` and `address` will be serialized as
+ * ```
+ * {
+ *   "user": {
+ *     "name": ...,
+ *     "email": ...
+ *   },
+ *   "address": ...
+ * }
+ * ```
+ *
+ *
+ * @param separatorCharacter - Separator character; must be exactly one character long
+ */
+export function nestedJson(separatorCharacter: string = "."): HalFormsEncoder {
+    if (separatorCharacter.length !== 1) {
+        throw new Error(`Nested property separator must be null or a string of length 1; got "${separatorCharacter}"`)
+    }
+    return new JsonHalFormsEncoder(separatorCharacter);
+}
+
+class JsonHalFormsEncoder implements HalFormsEncoder {
+
+    public constructor(private nestedObjectSeparator: string | null) {
+    }
+
+    public encode<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>, values: readonly AnyHalFormValue[]): TypedRequest<T, R> {
+        const jsonObject: Partial<T> = {};
+
+        values.forEach((value) => {
+            this.appendToJsonObject(jsonObject, value.property.name, value.value, value.property)
+        })
+
+        return createRequest(template.request, {
+            body: Representation.json(jsonObject as T)
+        });
+    }
+
+    private appendToJsonObject<T>(object: Partial<T>, key: string, value: AnyHalFormValue["value"], property: HalFormsProperty) {
+        if(value === undefined) {
+            // undefined never gets serialized anyways, don't write it to the object at all,
+            // so we don't create empty nested objects when all values are unset
+            return;
+        }
+        if(this.nestedObjectSeparator !== null) {
+            const [firstPart, nextParts] = key.split(this.nestedObjectSeparator, 2);
+            if(nextParts === undefined) {
+                this.safeWriteProperty(object, firstPart as keyof T, value, property);
+                return;
+            }
+
+            if(!(firstPart as keyof T in object)) {
+                this.safeWriteProperty(object, firstPart as keyof T, {}, property);
+            }
+            this.appendToJsonObject(object[firstPart as keyof T] as any, nextParts, value, property);
+        } else {
+            this.safeWriteProperty(object, key as keyof T, value, property);
+        }
+    }
+
+    private safeWriteProperty<T>(object: Partial<T>, key: keyof T, value: any, property: HalFormsProperty) {
+        if(key in object) {
+            throw new Error(`Can not write multiple values for property ${property.name}`);
+        }
+        object[key] = value;
+    }
+
+}

--- a/packages/hal-forms/src/codecs/errors.ts
+++ b/packages/hal-forms/src/codecs/errors.ts
@@ -1,0 +1,16 @@
+import { HalFormsTemplateError, HalFormsTemplate } from "..";
+
+
+/**
+ * Exception thrown when no codec is available for a HAL-FORMS template
+ */
+export class HalFormsCodecNotAvailableError extends HalFormsTemplateError {
+    // @internal This exception should only be constructed by this package itself
+    public constructor(
+        template: HalFormsTemplate<any>
+    ) {
+        super(template.name, `no encoder available for content type "${template.contentType}"`);
+        Object.setPrototypeOf(this, new.target.prototype);
+        this.name = HalFormsCodecNotAvailableError.name;
+    }
+}

--- a/packages/hal-forms/src/codecs/impl.ts
+++ b/packages/hal-forms/src/codecs/impl.ts
@@ -1,0 +1,75 @@
+import { TypedRequest, TypedRequestSpec } from "@contentgrid/typed-fetch";
+import { HalFormsTemplate } from "..";
+import { HalFormsCodec, HalFormsCodecs, HalFormsCodecsBuilder } from "./api";
+import { HalFormsEncoder } from "./encoders/api";
+import { AnyHalFormValue } from "../values/api";
+import { HalFormsCodecNotAvailableError } from "./errors";
+
+abstract class AbstractHalFormsCodecs implements HalFormsCodecs {
+    abstract findCodecFor<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>): HalFormsCodec<T, R> | null;
+
+    public requireCodecFor<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>): HalFormsCodec<T, R> {
+        const codec = this.findCodecFor(template);
+        if(codec === null) {
+            throw new HalFormsCodecNotAvailableError(template);
+        }
+        return codec;
+    }
+}
+
+class SingleEncoderHalFormsCodecs extends AbstractHalFormsCodecs {
+    public constructor(
+        private readonly contentType: string,
+        private readonly encoder: HalFormsEncoder
+    ) {
+        super();
+    }
+
+    public findCodecFor<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>): HalFormsCodec<T, R> | null {
+        if(template.contentType === this.contentType) {
+            return new HalFormsCodecImpl(template, this.encoder);
+        }
+        return null;
+    }
+}
+
+class HalFormsCodecImpl<T, R> implements HalFormsCodec<T, R> {
+    public constructor(
+        private readonly template: HalFormsTemplate<TypedRequestSpec<T, R>>,
+        private readonly encoder: HalFormsEncoder
+    ) {
+
+    }
+
+    public encode(values: readonly AnyHalFormValue[]): TypedRequest<T, R> {
+        return this.encoder.encode(this.template, values);
+    }
+
+}
+
+export default class HalFormsCodecsBuilderImpl extends AbstractHalFormsCodecs implements HalFormsCodecs, HalFormsCodecsBuilder {
+    private readonly codecs: HalFormsCodecs[] = [];
+
+    public registerEncoder(contentType: string, encoder: HalFormsEncoder): this {
+        return this.registerCodecs(new SingleEncoderHalFormsCodecs(contentType, encoder));
+    }
+
+    public registerCodecs(codecs: HalFormsCodecs): this {
+        this.codecs.push(codecs);
+        return this;
+    }
+
+    public build(): HalFormsCodecs {
+        return this;
+    }
+
+    public findCodecFor<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>): HalFormsCodec<T, R> |null{
+        for(const codecs of this.codecs) {
+            const codec = codecs.findCodecFor(template);
+            if(codec) {
+                return codec;
+            }
+        }
+        return null;
+    }
+}

--- a/packages/hal-forms/src/codecs/index.ts
+++ b/packages/hal-forms/src/codecs/index.ts
@@ -1,0 +1,13 @@
+export * from "./api";
+export * from "./errors";
+export * as Encoders from "./encoders";
+
+import { HalFormsCodecs } from "./api";
+import { nestedJson } from "./encoders";
+
+/**
+ * Default HAL-FORMS codecs
+ */
+export default HalFormsCodecs.builder()
+    .registerEncoder("application/json", nestedJson())
+    .build();

--- a/packages/hal-forms/src/errors.ts
+++ b/packages/hal-forms/src/errors.ts
@@ -17,9 +17,22 @@ export class HalTemplateNotFoundError extends HalFormsTemplateError {
     }
 }
 
-export class InvalidHalFormsOptionError extends HalFormsTemplateError {
-    public constructor(template: HalFormsTemplate<any>, readonly property: HalFormsProperty, message: string) {
-        super(template.name, `property ${property.name} has invalid options: ${message}`)
+export class HalFormsTemplatePropertyError extends HalFormsTemplateError {
+    public constructor(
+        template: HalFormsTemplate<any>,
+        readonly property: HalFormsProperty,
+        message: string
+    ) {
+        super(template.name, `property ${property.name}: ${message}`)
+        Object.setPrototypeOf(this, new.target.prototype);
+        this.name = InvalidHalFormsOptionError.name;
+    }
+
+}
+
+export class InvalidHalFormsOptionError extends HalFormsTemplatePropertyError {
+    public constructor(template: HalFormsTemplate<any>, property: HalFormsProperty, message: string) {
+        super(template, property, `invalid options: ${message}`)
         Object.setPrototypeOf(this, new.target.prototype);
         this.name = InvalidHalFormsOptionError.name;
     }

--- a/packages/hal-forms/src/model.ts
+++ b/packages/hal-forms/src/model.ts
@@ -16,6 +16,14 @@ class HalFormsTemplateImpl<Body, Response> implements HalFormsTemplate<TypedRequ
         return this.templateName;
     }
 
+    public get contentType() {
+        return this.model.contentType ?? "application/json";
+    }
+
+    public get title() {
+        return this.model.title ?? undefined;
+    }
+
     public get request(): TypedRequestSpec<Body, Response> {
         if(this.model.target !== undefined) {
             return {

--- a/packages/hal-forms/src/model.ts
+++ b/packages/hal-forms/src/model.ts
@@ -81,8 +81,8 @@ class HalFormsPropertyImpl<OptionType = unknown> implements HalFormsProperty<Opt
         return this.model.required ?? false;
     }
 
-    get type(): string | undefined {
-        return this.model?.type;
+    get type(): string {
+        return this.model?.type ?? "text";
     }
 
     get options(): HalFormsPropertyInlineOptions<OptionType> | HalFormsPropertyRemoteOptions<OptionType> {

--- a/packages/hal-forms/src/model.ts
+++ b/packages/hal-forms/src/model.ts
@@ -1,6 +1,6 @@
 import { HalFormsProperty, HalFormsPropertyInlineOptions, HalFormsPropertyOption, HalFormsPropertyRemoteOptions, HalFormsTemplate } from "./api";
 import { MATCH_ANYTHING, MATCH_NOTHING } from "./_internal";
-import { HalFormsPropertyOptionsShape, HalFormsPropertyShape, HalFormsTemplateShape, HalObjectWithTemplateShape, TemplateTypedRequest } from "./_shape";
+import { HalFormsPropertyOptionsShape, HalFormsPropertyShape, HalFormsPropertyValue, HalFormsTemplateShape, HalObjectWithTemplateShape, TemplateTypedRequest } from "./_shape";
 import { TypedRequestSpec } from "@contentgrid/typed-fetch";
 import { HalObjectShape } from "@contentgrid/hal/shape";
 import { HalTemplateNotFoundError, HalFormsTemplateError, InvalidHalFormsOptionError } from "./errors";
@@ -85,7 +85,7 @@ class HalFormsPropertyImpl<OptionType = unknown> implements HalFormsProperty<Opt
         return this.model?.type ?? "text";
     }
 
-    get options(): HalFormsPropertyInlineOptions<OptionType> | HalFormsPropertyRemoteOptions<OptionType> {
+    get options(): HalFormsPropertyInlineOptions<OptionType> | HalFormsPropertyRemoteOptions<OptionType> | null {
         const options = this.model?.options;
         if(options?.inline) {
             return new HalFormsPropertyInlineOptionsImpl(this._template, this, options)
@@ -93,7 +93,18 @@ class HalFormsPropertyImpl<OptionType = unknown> implements HalFormsProperty<Opt
         if(options?.link) {
             return new HalFormsPropertyRemoteOptionsImpl(this._template, this, options)
         }
-        return new HalFormsPropertyInlineOptionsImpl(this._template, this, options)
+        if(options) {
+            return new HalFormsPropertyInlineOptionsImpl(this._template, this, options)
+        } else {
+            return null;
+        }
+    }
+
+    get multiValue(): boolean {
+        if(this.options === null) {
+            return false;
+        }
+        return this.options.maxItems !== 1;
     }
 
     get regex(): RegExp {
@@ -120,6 +131,10 @@ class HalFormsPropertyImpl<OptionType = unknown> implements HalFormsProperty<Opt
 
     get prompt(): string | undefined {
         return this.model?.prompt;
+    }
+
+    get value(): HalFormsPropertyValue | undefined {
+        return this.model?.value;
     }
 }
 

--- a/packages/hal-forms/src/values/api.ts
+++ b/packages/hal-forms/src/values/api.ts
@@ -2,27 +2,92 @@ import { TypedRequestSpec } from "@contentgrid/typed-fetch";
 import { HalFormsProperty } from "../api";
 import { HalFormsPropertyType } from "../_shape";
 
+/**
+ * Value manager for a HAL-FORMS template
+ *
+ * The value manager can be used to keep track of user-supplied values entered into
+ * a form created from a HAL-FORMS template.
+ *
+ * The value manager is an immutable object; update methods return a new value manager object instead of modifying it.
+ */
 export interface HalFormValues<RS extends TypedRequestSpec<any, any>> {
-    readonly values: readonly HalFormValue[];
+    /**
+     * List of all HAL-FORMS properties and their respective value
+     */
+    readonly values: readonly AnyHalFormValue[];
 
-    value(propertyName: string): HalFormValue;
-    withValues(values: { [propertyName: string]: HalFormValue["value"] }): HalFormValues<RS>;
-    withValue(propertyName: string, value: HalFormValue["value"]): HalFormValues< RS>;
+    /**
+     * Retrieve the value for a specific named HAL-FORMS property
+     *
+     * @param propertyName - The name of the HAL-FORMS property to retrieve a value for
+     * @returns Object containing both the HAL-FORMS property and the value set for it
+     */
+    value(propertyName: string): AnyHalFormValue;
+
+    /**
+     * Set a HAL-FORMS property to a new value
+     *
+     * @param propertyName - The name of the HAL-FORMS property
+     * @param value - The value to set the HAL-FORMS property to
+     * @return New value manager with the specified property updated to its new value
+     */
+    withValue(propertyName: string, value: DefinedHalFormValue["value"]): HalFormValues<RS>;
+
+    /**
+     * Clears the value of a HAL-FORMS property
+     *
+     * Resets the value of a property to it's default value
+     *
+     * @param propertyName - The name of the HAL-FORMS property
+     * @return New value manager with the specified property cleared
+     */
     withoutValue(propertyName: string): HalFormValues<RS>;
+
+
+    /**
+     * Updates multiple HAL-FORMS properties to their new values
+     *
+     * @param values - Mapping of HAL-FORMS property names to their new values
+     * @return New value manager with the specified properties updated to their new values
+     */
+    withValues(values: { [propertyName: string]: DefinedHalFormValue["value"] }): HalFormValues<RS>;
 }
 
 
-interface HalFormValueInternal<FieldType, FieldValueType> {
+/**
+ * A value for a HAL-FORMS property of a certain type
+ * @typeParam FieldType - The HAL-FORMS property type
+ * @typeParam FieldValueType - The type of the value for the property
+ */
+interface TypedHalFormValue<FieldType extends HalFormsPropertyType, FieldValueType> {
     readonly property: HalFormsProperty & { type: FieldType };
-    readonly value: FieldValueType | readonly FieldValueType[] | null;
+    readonly value: FieldValueType | readonly FieldValueType[];
 }
 
-type SpecificHalFormValue = HalFormValueInternal<HalFormsPropertyType.file, File> |
-    HalFormValueInternal<HalFormsPropertyType.checkbox, boolean> |
-    HalFormValueInternal<HalFormsPropertyType.number | HalFormsPropertyType.range, number> |
-    HalFormValueInternal<HalFormsPropertyType.datetime|HalFormsPropertyType.datetime_local, Date>;
+/**
+ * Specific types of HAL-FORMS property types that map to a certain type
+ */
+type SpecificTypesHalFormValue = TypedHalFormValue<HalFormsPropertyType.file, File> |
+    TypedHalFormValue<HalFormsPropertyType.checkbox, boolean> |
+    TypedHalFormValue<HalFormsPropertyType.number | HalFormsPropertyType.range, number> |
+    TypedHalFormValue<HalFormsPropertyType.datetime | HalFormsPropertyType.datetime_local, Date>;
 
-export type HalFormValue = HalFormValueInternal<Exclude<HalFormsPropertyType, SpecificHalFormValue["property"]["type"]>, string>
-    | SpecificHalFormValue;
+/**
+ * All other HAL-FORMS property types map to a string
+ */
+type StringTypesHalFormValue = TypedHalFormValue<Exclude<HalFormsPropertyType, SpecificTypesHalFormValue["property"]["type"]>, string>;
 
-export type HalFormValueUndefined = HalFormValueInternal<string, undefined>;
+/**
+ * A HAL-FORMS property that has a value
+ */
+export type DefinedHalFormValue = SpecificTypesHalFormValue | StringTypesHalFormValue;
+
+/**
+ * A HAL-FORMS property that does not have any value
+ */
+export type UndefinedHalFormValue = TypedHalFormValue<HalFormsPropertyType, undefined>;
+
+/**
+ * A HAL-FORMS property that can either have a value or not have one
+ */
+export type AnyHalFormValue = DefinedHalFormValue | UndefinedHalFormValue;

--- a/packages/hal-forms/src/values/api.ts
+++ b/packages/hal-forms/src/values/api.ts
@@ -1,0 +1,28 @@
+import { TypedRequestSpec } from "@contentgrid/typed-fetch";
+import { HalFormsProperty } from "../api";
+import { HalFormsPropertyType } from "../_shape";
+
+export interface HalFormValues<RS extends TypedRequestSpec<any, any>> {
+    readonly values: readonly HalFormValue[];
+
+    value(propertyName: string): HalFormValue;
+    withValues(values: { [propertyName: string]: HalFormValue["value"] }): HalFormValues<RS>;
+    withValue(propertyName: string, value: HalFormValue["value"]): HalFormValues< RS>;
+    withoutValue(propertyName: string): HalFormValues<RS>;
+}
+
+
+interface HalFormValueInternal<FieldType, FieldValueType> {
+    readonly property: HalFormsProperty & { type: FieldType };
+    readonly value: FieldValueType | readonly FieldValueType[] | null;
+}
+
+type SpecificHalFormValue = HalFormValueInternal<HalFormsPropertyType.file, File> |
+    HalFormValueInternal<HalFormsPropertyType.checkbox, boolean> |
+    HalFormValueInternal<HalFormsPropertyType.number | HalFormsPropertyType.range, number> |
+    HalFormValueInternal<HalFormsPropertyType.datetime|HalFormsPropertyType.datetime_local, Date>;
+
+export type HalFormValue = HalFormValueInternal<Exclude<HalFormsPropertyType, SpecificHalFormValue["property"]["type"]>, string>
+    | SpecificHalFormValue;
+
+export type HalFormValueUndefined = HalFormValueInternal<string, undefined>;

--- a/packages/hal-forms/src/values/errors.ts
+++ b/packages/hal-forms/src/values/errors.ts
@@ -1,0 +1,38 @@
+import { HalFormsProperty, HalFormsTemplate } from "../api";
+import { HalFormsTemplatePropertyError } from "../errors";
+
+export class HalFormValueTypeError extends HalFormsTemplatePropertyError {
+    public constructor(
+        template: HalFormsTemplate<any>,
+        property: HalFormsProperty,
+        actualValue: any
+    ) {
+        super(template, property, `expected type ${property.type}${property.multiValue ? ' list' : ''}, but got ${safeValue(actualValue)}`)
+        Object.setPrototypeOf(this, new.target.prototype);
+        this.name = HalFormValueTypeError.name;
+    }
+}
+
+function safeValue(actualValue: any) {
+    if(actualValue === null) {
+        return "null";
+    } else if(actualValue === undefined) {
+        return "undefined";
+    } else if(Array.isArray(actualValue)) {
+        if(actualValue.length > 0) {
+            const values = uniq(actualValue.map(safeValue))
+            return "list of " + values.join(", ")
+        } else {
+            return "empty list";
+        }
+    }
+    const typeOf = typeof actualValue;
+    if(typeOf === "object") {
+        return Object.getPrototypeOf(actualValue).constructor.name ?? typeOf;
+    }
+    return typeOf;
+}
+
+function uniq(values: string[]): string[] {
+    return values.filter((val, idx, arr) => arr.indexOf(val) === idx);
+}

--- a/packages/hal-forms/src/values/errors.ts
+++ b/packages/hal-forms/src/values/errors.ts
@@ -1,7 +1,11 @@
 import { HalFormsProperty, HalFormsTemplate } from "../api";
 import { HalFormsTemplatePropertyError } from "../errors";
 
+/**
+ * An exception thrown when the type supplied for a HAL-FORMS property value is incorrect
+ */
 export class HalFormValueTypeError extends HalFormsTemplatePropertyError {
+    // @internal This exception should only be constructed by this package itself
     public constructor(
         template: HalFormsTemplate<any>,
         property: HalFormsProperty,

--- a/packages/hal-forms/src/values/impl.ts
+++ b/packages/hal-forms/src/values/impl.ts
@@ -1,0 +1,140 @@
+import { TypedRequestSpec } from "@contentgrid/typed-fetch";
+import { HalFormValue, HalFormValues } from "./api";
+import { HalFormsTemplate } from "../api";
+import { HalFormsPropertyType } from "../_shape";
+import { HalFormValueTypeError } from "./errors";
+
+type FormValueValue = Exclude<HalFormValue["value"], undefined>;
+
+type ValueMapping = { [propertyName: string]: FormValueValue };
+
+export class HalFormValuesImpl<RS extends TypedRequestSpec<any, any>> implements HalFormValues<RS> {
+    private readonly valueMapping: ValueMapping
+
+    public constructor(template: HalFormsTemplate<RS>);
+    // @internal
+    public constructor(template: HalFormsTemplate<RS>, valueMapping: ValueMapping);
+    public constructor(
+        private readonly template: HalFormsTemplate<RS>,
+        valueMapping: ValueMapping | null = null
+    ) {
+        // Initialize form fields with the defaults from the form
+        this.valueMapping = valueMapping ?? template.properties.reduce((valueMapping, property) => {
+            if(property.value === undefined) {
+                return valueMapping;
+            } else {
+                return this._appendValue(valueMapping, property.name, property.value);
+            }
+        }, {} as ValueMapping);
+    }
+
+    public get values(): readonly HalFormValue[] {
+        return this.template.properties.map(property => this.value(property.name));
+    }
+
+    public value(propertyName: string): HalFormValue {
+        const property = this.template.property(propertyName);
+        const value = this.valueMapping[property.name];
+        return {
+            property: property,
+            value: value === undefined ? property.value : value
+        } as HalFormValue;
+    }
+
+    public withValues(values: ValueMapping ): HalFormValues<RS> {
+        return Object.entries(values).reduce(
+            (values, newValue) => values.withValue(newValue[0], newValue[1]),
+            this as HalFormValues<RS>
+        );
+    }
+
+    public withValue(propertyName: string, value: FormValueValue): HalFormValues<RS> {
+        return new HalFormValuesImpl(
+            this.template,
+            this._appendValue(this.valueMapping, propertyName, value)
+        )
+    }
+
+    public withoutValue(propertyName: string): HalFormValues<RS> {
+        const property = this.template.property(propertyName);
+        const valueMappingCopy = { ...this.valueMapping };
+        delete valueMappingCopy[property.name];
+        return new HalFormValuesImpl(
+            this.template,
+            valueMappingCopy
+        );
+    }
+
+    private _appendValue(valueMapping: ValueMapping, propertyName: string, value: FormValueValue): ValueMapping {
+        const property = this.template.property(propertyName);
+        value = coerceToValidType(property.type, value);
+        if(Array.isArray(value)) {
+            if(!property.multiValue) {
+                // No options set on property, or maxItems set to 1
+                // => this is not a field supporting arrays
+                throw new HalFormValueTypeError(this.template, property, value);
+            } else {
+                // Options set on property; this field should support arrays
+                // => validate that each entry in the array is the correct type
+                value.forEach(v => {
+                    if(!isValidTypeValue(property.type, v)) {
+                        throw new HalFormValueTypeError(this.template, property, value);
+                    }
+                });
+            }
+        } else {
+            if(property.multiValue) {
+                throw new HalFormValueTypeError(this.template, property, value);
+            }
+            if (!isValidTypeValue(property.type, value)) {
+                throw new HalFormValueTypeError(this.template, property, value);
+            }
+        }
+
+        return {
+            ...valueMapping,
+            [property.name]: value
+        }
+    }
+
+}
+
+function coerceToValidType(type: HalFormsPropertyType | string, value: Extract<FormValueValue, any[]>): Extract<FormValueValue, any[]>;
+function coerceToValidType(type: HalFormsPropertyType | string, value: Exclude<FormValueValue, any[]>): Exclude<FormValueValue, any[]>;
+function coerceToValidType(type: HalFormsPropertyType | string, value: FormValueValue) {
+    if(Array.isArray(value)) {
+        return value.map(v => coerceToValidType(type, v));
+    }
+    switch(type) {
+        case HalFormsPropertyType.datetime:
+        case HalFormsPropertyType.datetime_local:
+            if(typeof value === "string") {
+                return new Date(value);
+            }
+    }
+    return value;
+}
+
+
+function isValidTypeValue(type: HalFormsPropertyType | string, value: FormValueValue) {
+    if(value === null) {
+        return true;
+    }
+    if(Array.isArray(value)) {
+        return false;
+    }
+    switch (type) {
+        case HalFormsPropertyType.file:
+            return value instanceof File;
+        case HalFormsPropertyType.checkbox:
+            return typeof value === "boolean";
+        case HalFormsPropertyType.number:
+        case HalFormsPropertyType.range:
+            return typeof value === "number" || typeof value === "bigint";
+        case HalFormsPropertyType.datetime:
+        case HalFormsPropertyType.datetime_local:
+            return value instanceof Date;
+        default:
+            return typeof value === "string";
+    }
+}

--- a/packages/hal-forms/src/values/index.ts
+++ b/packages/hal-forms/src/values/index.ts
@@ -1,0 +1,10 @@
+export * from "./api";
+export * from "./errors";
+
+import { TypedRequestSpec } from "@contentgrid/typed-fetch";
+import { HalFormValuesImpl } from "./impl";
+import { HalFormsTemplate } from "../api";
+
+export function createValues<RS extends TypedRequestSpec<any, any>>(template: HalFormsTemplate<RS>) {
+    return new HalFormValuesImpl(template);
+}

--- a/packages/hal-forms/src/values/index.ts
+++ b/packages/hal-forms/src/values/index.ts
@@ -4,7 +4,16 @@ export * from "./errors";
 import { TypedRequestSpec } from "@contentgrid/typed-fetch";
 import { HalFormValuesImpl } from "./impl";
 import { HalFormsTemplate } from "../api";
+import { HalFormValues } from "./api";
 
-export function createValues<RS extends TypedRequestSpec<any, any>>(template: HalFormsTemplate<RS>) {
+/**
+ * Creates a value-manager object for HAL-FORMS values.
+ *
+ * The value-manager stores form field values for a certain HAL-FORMS template.
+ *
+ * @param template - HAL-FORMS template to create values for
+ * @returns A new value-manager object
+ */
+export function createValues<RS extends TypedRequestSpec<any, any>>(template: HalFormsTemplate<RS>): HalFormValues<RS> {
     return new HalFormValuesImpl(template);
 }


### PR DESCRIPTION
- **Add support for hal-forms contentType & title properties**
- **Set default type for a HalFormsProperty to 'text'**
- **Add options fields (min/maxItems) to hal-forms model; detect multi-value properties**
- **Add value management for hal-forms**
- **Add tsdoc on hal-forms values API**
- **Add hal-forms codecs**
