### PR TITLE
Add HAL-FORMS encoders for uri-list, form-data & x-www-form-urlencoded

### DIFF
--- a/packages/hal-forms/README.md
+++ b/packages/hal-forms/README.md
@@ -83,6 +83,15 @@ After collecting user input, you probably want to send a request to the backend 
 
 The `@contentgrid/hal-forms/codecs` sub-package encodes the values according to the content-type required by the HAL-FORMS template.
 
+A default set of codecs is available, but you can also create your own set of codecs using `HalFormsCodecs.builder()`.
+
+The default set of codecs includes:
+ * Encoding as request parameters for GET, HEAD and DELETE HTTP methods
+ * "Nested" JSON encoding: form properties containing `.` are mapped to nested objects
+ * Simple forms (`x-www-form-urlencoded`)
+ * Multipart forms, for file upload (`multipart/form-data`)
+ * `text/uri-list` for forms containing only URIs
+
 <details>
 
 <summary>Code example for encoding form values with codecs</summary>

--- a/packages/hal-forms/__tests__/codecs.ts
+++ b/packages/hal-forms/__tests__/codecs.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "@jest/globals";
 import buildTemplate from "../src/builder";
-import { default as codecs, Encoders, HalFormsCodecNotAvailableError, HalFormsCodecs } from "../src/codecs";
+import { default as codecs, Encoders, HalFormsCodecNotAvailableError, HalFormsCodecPropertyTypeNotSupportedError, HalFormsCodecs } from "../src/codecs";
 import { HalFormsCodecImpl } from "../src/codecs/impl";
 import { createValues } from "../src/values";
 import { nestedJson } from "../src/codecs/encoders";
@@ -36,6 +36,12 @@ describe("HalFormsCodecs", () => {
                 .build();
             const c = empty.findCodecFor(form);
             expect(c).toBeNull();
+        })
+
+        test("throws when an unsupported property type is used", () => {
+            const fileForm = form.addProperty("file", p => p.withType("file"));
+            expect(() => codecs.findCodecFor(fileForm))
+                .toThrowError(new HalFormsCodecPropertyTypeNotSupportedError(fileForm, fileForm.property("file")));
         })
     });
 

--- a/packages/hal-forms/__tests__/codecs.ts
+++ b/packages/hal-forms/__tests__/codecs.ts
@@ -2,7 +2,6 @@ import { describe, expect, test } from "@jest/globals";
 import buildTemplate from "../src/builder";
 import { default as codecs, Encoders, HalFormsCodecNotAvailableError, HalFormsCodecPropertyTypeNotSupportedError, HalFormsCodecs } from "../src/codecs";
 import { HalFormsCodecImpl } from "../src/codecs/impl";
-import { createValues } from "../src/values";
 import { nestedJson } from "../src/codecs/encoders";
 
 const form = buildTemplate("POST", "http://localhost/invoices")
@@ -89,87 +88,4 @@ describe("Default codecs", () => {
             .withContentType("application/json");
         expect(codecs.findCodecFor(form)).toBeNull();
     })
-})
-
-describe("Encoders.json()", () => {
-    const values = createValues(form);
-    const codecs = HalFormsCodecs.builder()
-        .registerEncoder("application/json", Encoders.json())
-        .build();
-
-    test("Encodes default values", () => {
-        const encoded = codecs.requireCodecFor(form).encode(values.values);
-
-        expect(encoded).toBeInstanceOf(Request);
-
-        expect(encoded.json())
-            .resolves
-            .toEqual({
-                "name": "Jefke"
-            });
-    })
-
-    test("Encodes nested values as flat JSON", () => {
-
-        const encoded = codecs.requireCodecFor(form).encode(
-            values
-                .withValue("total.net", 123)
-                .withValue("total.vat", 456)
-                .values
-        );
-
-        expect(encoded).toBeInstanceOf(Request);
-
-        expect(encoded.json())
-            .resolves
-            .toEqual({
-                "name": "Jefke",
-                "total.net": 123,
-                "total.vat": 456
-            })
-    });
-
-})
-
-describe("Encoders.nestedJson()", () => {
-    const values = createValues(form);
-    const codecs = HalFormsCodecs.builder()
-        .registerEncoder("application/json", Encoders.nestedJson())
-        .build();
-
-    test("Encodes default values", () => {
-        const encoded = codecs.requireCodecFor(form).encode(values.values);
-
-        expect(encoded).toBeInstanceOf(Request);
-        expect(encoded.headers.get("content-type")).toEqual("application/json")
-
-        expect(encoded.json())
-            .resolves
-            .toEqual({
-                "name": "Jefke"
-            });
-    })
-
-    test("Encodes nested values as flat JSON", () => {
-
-        const encoded = codecs.requireCodecFor(form).encode(
-            values
-                .withValue("total.net", 123)
-                .withValue("total.vat", 456)
-                .values
-        );
-
-        expect(encoded).toBeInstanceOf(Request);
-
-        expect(encoded.json())
-            .resolves
-            .toEqual({
-                "name": "Jefke",
-                "total": {
-                    "net": 123,
-                    "vat": 456
-                }
-            })
-    });
-
 })

--- a/packages/hal-forms/__tests__/codecs.ts
+++ b/packages/hal-forms/__tests__/codecs.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "@jest/globals";
 import buildTemplate from "../src/builder";
 import { default as codecs, Encoders, HalFormsCodecNotAvailableError, HalFormsCodecPropertyTypeNotSupportedError, HalFormsCodecs } from "../src/codecs";
 import { HalFormsCodecImpl } from "../src/codecs/impl";
-import { nestedJson } from "../src/codecs/encoders";
+import { nestedJson, urlencodedQuerystring } from "../src/codecs/encoders";
 
 const form = buildTemplate("POST", "http://localhost/invoices")
     .withContentType("application/json")
@@ -80,12 +80,14 @@ describe("Default codecs", () => {
 
     test("form method=GET, without contentType", () => {
         const form = buildTemplate("GET", "/");
-        expect(codecs.findCodecFor(form)).toBeNull();
+        expect(codecs.findCodecFor(form)).toEqual(new HalFormsCodecImpl(form, urlencodedQuerystring()));
     })
 
     test("form method=GET, contentType=application/json", () => {
+        // Note: the HAL-FORMS spec requires that all forms with methods GET, DELETE & HEAD encode properties in the query string
+        // It does not matter which content type is set for the form
         const form = buildTemplate("GET", "/")
             .withContentType("application/json");
-        expect(codecs.findCodecFor(form)).toBeNull();
+        expect(codecs.findCodecFor(form)).toEqual(new HalFormsCodecImpl(form, urlencodedQuerystring()));
     })
 })

--- a/packages/hal-forms/__tests__/encoders.ts
+++ b/packages/hal-forms/__tests__/encoders.ts
@@ -172,3 +172,196 @@ describe("Encoders.nestedJson()", () => {
     })
 
 })
+
+describe("Encoders.uriList()", () => {
+    const codecs = HalFormsCodecs.builder()
+        .registerEncoder(() => true, Encoders.uriList())
+        .build();
+
+    test("Encodes URI value from a single single-value field", () => {
+        const form = buildTemplate("POST", "http://localhost/test")
+            .addProperty("senders", b => b.withType("url"))
+        const values = createValues(form);
+        const encoded = codecs.requireCodecFor(form).encode(
+            values
+                .withValue("senders", "http://localhost/123")
+        );
+
+        expect(encoded).toBeInstanceOf(Request);
+        expect(encoded.headers.get("content-type")).toEqual("text/uri-list");
+
+        expect(encoded.text())
+            .resolves
+            .toEqual("http://localhost/123\r\n");
+    })
+
+    test("Encodes URI values from a single multi-value field", () => {
+        const form = buildTemplate("POST", "http://localhost/test")
+            .withContentType("text/uri-list")
+            .addProperty("senders", b => b.withType("url")
+                .withOptions(b => b.withMinItems(0))
+            )
+        const values = createValues(form);
+        const encoded = codecs.requireCodecFor(form).encode(
+            values
+                .withValue("senders", ["http://localhost/123", "http://localhost/456"])
+        );
+
+        expect(encoded.text())
+            .resolves
+            .toEqual("http://localhost/123\r\nhttp://localhost/456\r\n");
+    })
+
+    test("Encodes URI values from multiple fields", () => {
+        const form = buildTemplate("POST", "http://localhost/test")
+            .addProperty("senders", b => b.withType("url")
+                .withOptions(b => b.withMinItems(0))
+            )
+            .addProperty("receivers", b => b.withType("url")
+                .withOptions(b => b.withMinItems(0))
+            )
+        const values = createValues(form);
+        const encoded = codecs.requireCodecFor(form).encode(
+            values
+                .withValue("senders", ["http://localhost/123", "http://localhost/456"])
+                .withValue("receivers", ["http://localhost/recv/1", "http://localhost/recv/2"])
+        );
+
+        expect(encoded.text())
+            .resolves
+            .toEqual("http://localhost/123\r\nhttp://localhost/456\r\n"+
+            "http://localhost/recv/1\r\nhttp://localhost/recv/2\r\n"
+            );
+    })
+
+    test("Encodes URI values from multiple fields with only one filled in", () => {
+        const form = buildTemplate("POST", "http://localhost/test")
+            .addProperty("sender", b => b.withType("url"))
+            .addProperty("receivers", b => b.withType("url")
+                .withOptions(b => b.withMinItems(0))
+            )
+            .addProperty("cc", b => b.withType("url")
+                .withOptions(b => b.withMinItems(0))
+            )
+        const values = createValues(form);
+        const encoded = codecs.requireCodecFor(form).encode(
+            values
+                .withValue("receivers", ["http://localhost/recv/1", "http://localhost/recv/2"])
+        );
+
+        expect(encoded.text())
+            .resolves
+            .toEqual("http://localhost/recv/1\r\nhttp://localhost/recv/2\r\n");
+    })
+
+    test("Refuses to encode a non-url property", () => {
+        const form = buildTemplate("POST", "http://localhost/test")
+            .addProperty("sender", b => b.withType("text"))
+            .addProperty("receivers", b => b.withType("url")
+                .withOptions(b => b.withMinItems(0))
+            )
+            .addProperty("cc", b => b.withType("url")
+                .withOptions(b => b.withMinItems(0))
+            )
+        const values = createValues(form);
+        expect(() =>codecs.requireCodecFor(form).encode(
+            values
+                .withValue("receivers", ["http://localhost/recv/1", "http://localhost/recv/2"])
+        )).toThrow();
+    })
+})
+
+describe("Encoders.multipartForm()", () => {
+    const codecs = HalFormsCodecs.builder()
+        .registerEncoder(() => true, Encoders.multipartForm())
+        .build();
+
+    test("Encodes default values", () => {
+        const encoded = codecs.requireCodecFor(plainForm)
+            .encode(plainEmptyValues);
+
+        expect(encoded).toBeInstanceOf(Request);
+        expect(encoded.headers.get("content-type")).toMatch(/^multipart\/form-data;/)
+
+        const expected = new FormData();
+        expected.append("name", "Jefke");
+        expected.append("active", "false");
+
+        expect(encoded.formData())
+            .resolves
+            .toEqual(expected);
+    })
+
+    test("Encodes values", () => {
+        const encoded = codecs.requireCodecFor(plainForm)
+            .encode(plainFilledValues);
+
+        const expected = new FormData();
+        expected.append("created_at", "2024-03-22T08:12:29.000Z");
+        expected.append("total.net", "123");
+        expected.append("total.vat", "456");
+        expected.append("senders", "http://localhost/users/1");
+        expected.append("senders", "http://localhost/users/2");
+        expected.append("name", "Pierre");
+        expected.append("active", "true");
+        expect(encoded.formData())
+            .resolves
+            .toEqual(expected)
+    });
+
+    test("Encodes file values", () => {
+        const encoded = codecs.requireCodecFor(fileForm).encode(fileFilledValues);
+
+        const expected = new FormData();
+        expected.append("created_at", "2024-03-22T08:12:29.000Z");
+        expected.append("total.net", "123");
+        expected.append("total.vat", "456");
+        expected.append("senders", "http://localhost/users/1");
+        expected.append("senders", "http://localhost/users/2");
+        expected.append("name", "Pierre");
+        expected.append("active", "true");
+        expected.append("file", plainTextFile);
+        expect(encoded.formData())
+            .resolves
+            .toEqual(expected)
+    })
+})
+
+describe("Encoders.urlencodedForm()", () => {
+    const codecs = HalFormsCodecs.builder()
+        .registerEncoder(() => true, Encoders.urlencodedForm())
+        .build();
+    test("Encodes default values", () => {
+        const encoded = codecs.requireCodecFor(plainForm)
+        .encode(plainEmptyValues);
+
+        expect(encoded).toBeInstanceOf(Request);
+        expect(encoded.headers.get("content-type")).toMatch(/^application\/x-www-form-urlencoded;/)
+
+        expect(encoded.text())
+            .resolves
+            .toEqual("name=Jefke&active=false");
+    })
+
+    test("Encodes values", () => {
+        const encoded = codecs.requireCodecFor(plainForm)
+            .encode(plainFilledValues);
+
+        expect(encoded.text())
+            .resolves
+            .toEqual("created_at=2024-03-22T08%3A12%3A29.000Z&total.net=123&total.vat=456&senders=http%3A%2F%2Flocalhost%2Fusers%2F1&senders=http%3A%2F%2Flocalhost%2Fusers%2F2&name=Pierre&active=true")
+    });
+
+    test("Refuses to encode files", () => {
+        expect(() => codecs.requireCodecFor(fileForm)
+            .encode(fileFilledValues))
+            .toThrowError();
+    })
+
+    test("Refuses to encode files, even when they are not filled in", () => {
+        expect(() => codecs.requireCodecFor(fileForm)
+            .encode(fileEmptyValues))
+            .toThrowError();
+    })
+
+})

--- a/packages/hal-forms/__tests__/encoders.ts
+++ b/packages/hal-forms/__tests__/encoders.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "@jest/globals";
+import buildTemplate from "../src/builder";
+import { createValues } from "../src/values";
+import { Encoders, HalFormsCodecs } from "../src/codecs";
+
+class File extends Blob {
+
+    public constructor(fileBits: BlobPart[], public name: string, private options?: FilePropertyBag) {
+        super(fileBits, options);
+    }
+
+    get lastModified(): number {
+        return this.options?.lastModified ?? 0;
+    }
+
+    get webkitRelativePath(): string {
+        return this.name;
+    }
+}
+
+global.File = File;
+
+const plainForm = buildTemplate("POST", "http://localhost/invoices")
+    .addProperty("created_at", b => b
+        .withType("datetime")
+        .withRequired(true)
+    )
+    .addProperty("total.net", b => b
+        .withType("number")
+    )
+    .addProperty("total.vat", b => b
+        .withType("number")
+    )
+    .addProperty("senders", b => b.withType("url")
+        .withOptions(b => b.withMinItems(0))
+    )
+    .addProperty("name", b => b.withValue("Jefke"))
+    .addProperty("active", b => b.withType("checkbox").withValue(false));
+
+const plainEmptyValues = createValues(plainForm);
+
+const createdAt = new Date("2024-03-22T09:12:29+01:00");
+
+const plainFilledValues = plainEmptyValues
+    .withValue("created_at", createdAt)
+    .withValue("total.net", 123)
+    .withValue("total.vat", 456)
+    .withValue("senders", ["http://localhost/users/1", "http://localhost/users/2"])
+    .withValue("name", "Pierre")
+    .withValue("active", true);
+
+const plainTextFile = new File([], "my-file.txt", {
+    type: "text/plain"
+});
+
+const fileForm = plainForm
+    .addProperty("file", b => b.withType("file"));
+
+const fileEmptyValues = createValues(fileForm);
+const fileFilledValues = fileEmptyValues
+    .withValue("file", plainTextFile);
+
+describe("Encoders.json()", () => {
+    const codecs = HalFormsCodecs.builder()
+        .registerEncoder(() => true, Encoders.json())
+        .build();
+
+    test("Encodes default values", () => {
+        const encoded = codecs.requireCodecFor(plainForm)
+        .encode(plainEmptyValues.values);
+
+        expect(encoded).toBeInstanceOf(Request);
+
+        expect(encoded.headers.get("content-type")).toEqual("application/json");
+
+        expect(encoded.json())
+            .resolves
+            .toEqual({
+                "name": "Jefke",
+                "active": false
+            });
+    })
+
+    test("Encodes nested values as flat JSON", () => {
+        const encoded = codecs.requireCodecFor(plainForm)
+            .encode(plainFilledValues.values);
+
+        expect(encoded.headers.get("content-type")).toEqual("application/json");
+        expect(encoded.json())
+            .resolves
+            .toEqual({
+                "name": "Pierre",
+                "created_at": "2024-03-22T08:12:29.000Z",
+                "total.net": 123,
+                "total.vat": 456,
+                "senders": ["http://localhost/users/1", "http://localhost/users/2"],
+                "active": true
+            })
+    });
+
+    test("Refuses to encode files", () => {
+        expect(() => codecs.requireCodecFor(fileForm)
+            .encode(fileFilledValues.values))
+            .toThrowError();
+    })
+
+    test("Refuses to encode files, even when they are not filled in", () => {
+        expect(() => codecs.requireCodecFor(fileForm)
+            .encode(fileEmptyValues.values))
+            .toThrowError();
+    })
+
+})
+
+describe("Encoders.nestedJson()", () => {
+    const codecs = HalFormsCodecs.builder()
+        .registerEncoder(() => true, Encoders.nestedJson())
+        .build();
+
+    test("Encodes default values", () => {
+        const encoded = codecs.requireCodecFor(plainForm)
+        .encode(plainEmptyValues.values);
+
+        expect(encoded).toBeInstanceOf(Request);
+        expect(encoded.headers.get("content-type")).toEqual("application/json");
+
+        expect(encoded.json())
+            .resolves
+            .toEqual({
+                "name": "Jefke",
+                "active": false
+            });
+    })
+
+    test("Encodes nested values as JSON", () => {
+        const encoded = codecs.requireCodecFor(plainForm)
+            .encode(plainFilledValues.values);
+
+        expect(encoded.headers.get("content-type")).toEqual("application/json");
+
+        expect(encoded.json())
+            .resolves
+            .toEqual({
+                "name": "Pierre",
+                "created_at": "2024-03-22T08:12:29.000Z",
+                "total": {
+                    "net": 123,
+                    "vat": 456
+                },
+                "senders": ["http://localhost/users/1", "http://localhost/users/2"],
+                "active": true
+            })
+    });
+
+    test("Refuses to encode files", () => {
+        expect(() => codecs.requireCodecFor(fileForm)
+            .encode(fileFilledValues.values))
+            .toThrowError();
+    })
+    test("Refuses to encode files, even when they are not filled in", () => {
+        expect(() => codecs.requireCodecFor(fileForm)
+            .encode(fileEmptyValues.values))
+            .toThrowError();
+    })
+
+})

--- a/packages/hal-forms/__tests__/encoders.ts
+++ b/packages/hal-forms/__tests__/encoders.ts
@@ -110,6 +110,13 @@ describe("Encoders.json()", () => {
             .toThrowError();
     })
 
+    test("Encodes using a custom content type if set on the form", () => {
+        const encoded = codecs.requireCodecFor(plainForm.withContentType("application/hal+json"))
+            .encode(plainFilledValues.values)
+
+        expect(encoded.headers.get("content-type")).toEqual("application/hal+json");
+    })
+
 })
 
 describe("Encoders.nestedJson()", () => {

--- a/packages/hal-forms/__tests__/encoders.ts
+++ b/packages/hal-forms/__tests__/encoders.ts
@@ -58,6 +58,7 @@ const fileForm = plainForm
 
 const fileEmptyValues = createValues(fileForm);
 const fileFilledValues = fileEmptyValues
+    .withValues(plainFilledValues.valueMap)
     .withValue("file", plainTextFile);
 
 describe("Encoders.json()", () => {
@@ -67,7 +68,7 @@ describe("Encoders.json()", () => {
 
     test("Encodes default values", () => {
         const encoded = codecs.requireCodecFor(plainForm)
-        .encode(plainEmptyValues.values);
+        .encode(plainEmptyValues);
 
         expect(encoded).toBeInstanceOf(Request);
 
@@ -83,7 +84,7 @@ describe("Encoders.json()", () => {
 
     test("Encodes nested values as flat JSON", () => {
         const encoded = codecs.requireCodecFor(plainForm)
-            .encode(plainFilledValues.values);
+            .encode(plainFilledValues);
 
         expect(encoded.headers.get("content-type")).toEqual("application/json");
         expect(encoded.json())
@@ -100,19 +101,19 @@ describe("Encoders.json()", () => {
 
     test("Refuses to encode files", () => {
         expect(() => codecs.requireCodecFor(fileForm)
-            .encode(fileFilledValues.values))
+            .encode(fileFilledValues))
             .toThrowError();
     })
 
     test("Refuses to encode files, even when they are not filled in", () => {
         expect(() => codecs.requireCodecFor(fileForm)
-            .encode(fileEmptyValues.values))
+            .encode(fileEmptyValues))
             .toThrowError();
     })
 
     test("Encodes using a custom content type if set on the form", () => {
         const encoded = codecs.requireCodecFor(plainForm.withContentType("application/hal+json"))
-            .encode(plainFilledValues.values)
+            .encode(plainFilledValues)
 
         expect(encoded.headers.get("content-type")).toEqual("application/hal+json");
     })
@@ -126,7 +127,7 @@ describe("Encoders.nestedJson()", () => {
 
     test("Encodes default values", () => {
         const encoded = codecs.requireCodecFor(plainForm)
-        .encode(plainEmptyValues.values);
+        .encode(plainEmptyValues);
 
         expect(encoded).toBeInstanceOf(Request);
         expect(encoded.headers.get("content-type")).toEqual("application/json");
@@ -141,7 +142,7 @@ describe("Encoders.nestedJson()", () => {
 
     test("Encodes nested values as JSON", () => {
         const encoded = codecs.requireCodecFor(plainForm)
-            .encode(plainFilledValues.values);
+            .encode(plainFilledValues);
 
         expect(encoded.headers.get("content-type")).toEqual("application/json");
 
@@ -161,12 +162,12 @@ describe("Encoders.nestedJson()", () => {
 
     test("Refuses to encode files", () => {
         expect(() => codecs.requireCodecFor(fileForm)
-            .encode(fileFilledValues.values))
+            .encode(fileFilledValues))
             .toThrowError();
     })
     test("Refuses to encode files, even when they are not filled in", () => {
         expect(() => codecs.requireCodecFor(fileForm)
-            .encode(fileEmptyValues.values))
+            .encode(fileEmptyValues))
             .toThrowError();
     })
 

--- a/packages/hal-forms/__tests__/values.ts
+++ b/packages/hal-forms/__tests__/values.ts
@@ -153,6 +153,25 @@ describe("values", () => {
 
     })
 
+    describe("#valueMap", () => {
+        test("Default values", () => {
+            expect(formValues.valueMap).toEqual({
+                "name": "Jefke"
+            })
+        })
+        test("with other value types", () => {
+            const file = new File([], "example.jpg", {"type": "image/jpeg"});
+            expect(formValues
+                .withValue("total.net", 120)
+                .withValue("picture", file)
+                .valueMap).toEqual({
+                    name: "Jefke",
+                    "total.net": 120,
+                    picture: file
+                })
+        })
+    })
+
 })
 
 describe("HalFormValueTypeError", () => {

--- a/packages/hal-forms/src/codecs/api.ts
+++ b/packages/hal-forms/src/codecs/api.ts
@@ -30,6 +30,9 @@ export interface HalFormsCodecs {
      * @see {@link HalFormsCodecs#requireCodecFor} for the variant that throws an error when no codec is available
      *
      * @param template - The HAL-FORMS template to look up a codec for
+     *
+     * @throws {@link ./errors#HalFormsCodecPropertyTypeNotSupportedError} when the selected codec does not support a certain property
+     *
      * @return A codec if one is available, or null if no codec is available
      */
     findCodecFor<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>): HalFormsCodec<T, R> | null;
@@ -37,11 +40,12 @@ export interface HalFormsCodecs {
     /**
      * Require a codec for a HAL-FORMS template
      *
-     * @see {@link HalFormsCodecs#requireCodecFor} for the variant that throws an error when no codec is available
+     * @see {@link HalFormsCodecs#findCodecFor} for the variant that throws an error when no codec is available
      *
      * @param template - The HAL-FORMS template to look up a codec for
      *
      * @throws {@link ./errors#HalFormsCodecNotAvailableError} when no codec is available
+     * @throws {@link ./errors#HalFormsCodecPropertyTypeNotSupportedError} when the selected codec does not support a certain property
      *
      * @return A codec
      */

--- a/packages/hal-forms/src/codecs/api.ts
+++ b/packages/hal-forms/src/codecs/api.ts
@@ -1,8 +1,8 @@
 import { TypedRequest, TypedRequestSpec } from "@contentgrid/typed-fetch";
 import { HalFormsTemplate } from "../api";
-import { AnyHalFormValue } from "../values";
 import { HalFormsEncoder } from "./encoders";
 import HalFormsCodecsImpl from "./impl";
+import { HalFormValues, HalFormValuesMap } from "../values/api";
 
 /**
  * HAL-FORMS codec
@@ -11,11 +11,18 @@ import HalFormsCodecsImpl from "./impl";
  */
 export interface HalFormsCodec<T, R> {
     /**
+     * Encode a javascript object into a request
+     * @param values - The HAL-FORMS values to encode
+     * @returns A {@link TypedRequest} that can be sent with {@link fetch}
+     */
+    encode(values: HalFormValuesMap): TypedRequest<T, R>
+
+    /**
      * Encode HAL-FORMS values into a request
      * @param values - The HAL-FORMS values to encode
      * @returns A {@link TypedRequest} that can be sent with {@link fetch}
      */
-    encode(values: readonly AnyHalFormValue[]): TypedRequest<T, R>
+    encode(values: HalFormValues<TypedRequestSpec<T, R>>): TypedRequest<T, R>
 }
 
 /**

--- a/packages/hal-forms/src/codecs/encoders/api.ts
+++ b/packages/hal-forms/src/codecs/encoders/api.ts
@@ -1,5 +1,5 @@
 import { TypedRequest, TypedRequestSpec } from "@contentgrid/typed-fetch";
-import { HalFormsTemplate } from "../../api";
+import { HalFormsProperty, HalFormsTemplate } from "../../api";
 import { AnyHalFormValue } from "../../values";
 
 /**
@@ -18,4 +18,11 @@ export interface HalFormsEncoder {
      * @param values - The HAL-FORMS values to encode
      */
     encode<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>, values: readonly AnyHalFormValue[]): TypedRequest<T, R>;
+
+    /**
+     * Checks if this encoder supports encoding a certain HAL-FORMS property
+     *
+     * @param property - HAL-FORMS property to check support for
+     */
+    supportsProperty(property: HalFormsProperty): boolean;
 }

--- a/packages/hal-forms/src/codecs/encoders/form.ts
+++ b/packages/hal-forms/src/codecs/encoders/form.ts
@@ -1,0 +1,105 @@
+import { TypedRequestSpec, TypedRequest, createRequest, Representation } from "@contentgrid/typed-fetch";
+import { HalFormsEncoder } from "./api";
+import { HalFormsProperty, HalFormsTemplate } from "../../api";
+import { AnyHalFormValue, DefinedHalFormValue } from "../../values";
+import { HalFormsPropertyType } from "../../_shape";
+
+/**
+ * Encodes HAL-FORMS as multipart form
+ *
+ * This encoder creates a multipart form, which can be used to upload files.
+ *
+ * This encoding format serializes to string or File: Dates, numbers and booleans will be converted to strings
+ */
+export function multipartForm(): HalFormsEncoder {
+    return new FormDataEncoder();
+}
+
+/**
+ * Encodes HAL-FORMS as urlencoded forms
+ *
+ * This encoding format serializes to string: Dates, numbers and booleans will be converted to strings
+ * Files are not supported.
+ */
+export function urlencodedForm(): HalFormsEncoder {
+    return new UrlencodedFormEncoder();
+}
+
+type FormLike = FormData | URLSearchParams;
+
+abstract class AbstractFormDataEncoder<F extends FormLike> implements HalFormsEncoder {
+
+    public encode<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>, values: readonly AnyHalFormValue[]): TypedRequest<T, R> {
+        const formData = this.createData();
+        values.forEach(value => {
+            this.toValues(value).forEach(v => {
+                this.appendToData(formData, value.property, v);
+            })
+        })
+
+        return createRequest(template.request, {
+            // content-type header is set automatically
+            body: Representation.createUnsafe(formData),
+        })
+    }
+
+    public abstract supportsProperty(property: HalFormsProperty<unknown>): boolean;
+
+    protected abstract createData(): F;
+    protected abstract appendToData(form: F, property: HalFormsProperty, value: string | Blob): undefined;
+
+    private toValues(value: AnyHalFormValue): readonly (string|Blob)[] {
+        const v = value.value;
+        if(v == undefined) {
+            return [];
+        }
+        if (Array.isArray(v)) {
+            return v.map(v => this.toStringOrBlob(v));
+        }
+        return [this.toStringOrBlob(v as Exclude<typeof v, readonly any[]>)];
+    }
+
+    private toStringOrBlob(value: Exclude<DefinedHalFormValue["value"], readonly any[]>): string | Blob {
+        if(value instanceof Blob) {
+            return value;
+        } else if(value instanceof Date) {
+            return value.toISOString();
+        } else {
+            return "" + value;
+        }
+    }
+}
+
+class FormDataEncoder extends AbstractFormDataEncoder<FormData> {
+    protected override createData(): FormData {
+        return new FormData();
+    }
+
+    protected override appendToData(form: FormData, property: HalFormsProperty<unknown>, value: string | Blob): undefined {
+        form.append(property.name, value);
+    }
+
+    public override supportsProperty(_property: HalFormsProperty<unknown>): boolean {
+        return true;
+    }
+
+}
+
+
+class UrlencodedFormEncoder extends AbstractFormDataEncoder<URLSearchParams> {
+    protected override createData(): URLSearchParams {
+        return new URLSearchParams();
+    }
+
+    protected override appendToData(form: URLSearchParams, property: HalFormsProperty<unknown>, value: string | Blob): undefined {
+        if(value instanceof Blob) {
+            throw new Error("Can not encode blob");
+        }
+        form.append(property.name, value);
+    }
+
+    public override supportsProperty(property: HalFormsProperty<unknown>): boolean {
+        return property.type !== HalFormsPropertyType.file;
+    }
+
+}

--- a/packages/hal-forms/src/codecs/encoders/index.ts
+++ b/packages/hal-forms/src/codecs/encoders/index.ts
@@ -1,2 +1,4 @@
 export type * from "./api";
-export { json, nestedJson } from "./json"
+export * from "./json"
+export * from "./uri-list";
+export * from "./form";

--- a/packages/hal-forms/src/codecs/encoders/json.ts
+++ b/packages/hal-forms/src/codecs/encoders/json.ts
@@ -2,12 +2,14 @@ import { Representation, TypedRequest, TypedRequestSpec, createRequest } from "@
 import { HalFormsProperty, HalFormsTemplate } from "../../api";
 import { AnyHalFormValue } from "../../values/api";
 import { HalFormsEncoder } from "./api";
+import { HalFormsPropertyType } from "../../_shape";
 
 /**
  * Encodes HAL-FORMS values as a JSON object
  *
  * The JSON object is created as a simple object mapping a HAL-FORMS property name to its value.
  * Nested objects are not supported.
+ * Files are not supported.
  */
 export function json(): HalFormsEncoder {
     return new JsonHalFormsEncoder(null);
@@ -18,6 +20,7 @@ export function json(): HalFormsEncoder {
  *
  * The JSON object is created as an object mapping a HAL-FORMS property name to their values.
  * Nested objects are supported; The separator character accesses nested JSON objects.
+ * Files are not supported.
  *
  * e.g. A HAL-FORM with properties `user.name`, `user.email` and `address` will be serialized as
  * ```
@@ -58,6 +61,10 @@ class JsonHalFormsEncoder implements HalFormsEncoder {
             },
             body: Representation.json(jsonObject as T)
         });
+    }
+
+    public supportsProperty(property: HalFormsProperty<unknown>): boolean {
+        return property.type !== HalFormsPropertyType.file;
     }
 
     private appendToJsonObject<T>(object: Partial<T>, key: string, value: AnyHalFormValue["value"], property: HalFormsProperty) {

--- a/packages/hal-forms/src/codecs/encoders/uri-list.ts
+++ b/packages/hal-forms/src/codecs/encoders/uri-list.ts
@@ -1,0 +1,47 @@
+import { TypedRequestSpec, TypedRequest, createRequest, Representation } from "@contentgrid/typed-fetch";
+import { HalFormsProperty, HalFormsTemplate } from "../..";
+import { AnyHalFormValue } from "../../values";
+import { HalFormsEncoder } from "./api";
+import { HalFormsPropertyType } from "../../_shape";
+
+/**
+ * Encodes HAL-FORMS as newline-separated URLs
+ *
+ * This encoder only supports HAL-FORMS properties of type 'url'; presence of other properties will result in an exception being thrown.
+ *
+ * Typically, a form would contain exactly one property.
+ * This encoding format only serializes the values, not the property names.
+ * If multiple properties of are present, they will be indistinguishable from each other
+ */
+export function uriList(): HalFormsEncoder {
+    return new UriListEncoder();
+}
+
+class UriListEncoder implements HalFormsEncoder {
+    public encode<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>, values: readonly AnyHalFormValue[]): TypedRequest<T, R> {
+        const uriList = values
+            .flatMap(val => this.toUrlValue(val))
+            .filter(val => val !== undefined)
+            .map(val => val+"\r\n") // Ensure that every line is newline-terminated
+            .join("");
+
+        return createRequest(template.request, {
+            headers: {
+                "Content-Type": template.contentType ?? "text/uri-list"
+            },
+            body: Representation.createUnsafe(uriList),
+        })
+    }
+
+    public supportsProperty(property: HalFormsProperty<unknown>): boolean {
+        return property.type === HalFormsPropertyType.url;
+    }
+
+    private toUrlValue(value: AnyHalFormValue): readonly (string | undefined)[] {
+        if (Array.isArray(value.value)) {
+            return value.value;
+        } else {
+            return [value.value as string | undefined];
+        }
+    }
+}

--- a/packages/hal-forms/src/codecs/errors.ts
+++ b/packages/hal-forms/src/codecs/errors.ts
@@ -1,4 +1,4 @@
-import { HalFormsTemplateError, HalFormsTemplate } from "..";
+import { HalFormsTemplateError, HalFormsTemplate, HalFormsTemplatePropertyError, HalFormsProperty } from "..";
 
 
 /**
@@ -13,4 +13,20 @@ export class HalFormsCodecNotAvailableError extends HalFormsTemplateError {
         Object.setPrototypeOf(this, new.target.prototype);
         this.name = HalFormsCodecNotAvailableError.name;
     }
+}
+
+/**
+ * Exception thrown when the codec does not support a certain type of property
+ */
+export class HalFormsCodecPropertyTypeNotSupportedError extends HalFormsTemplatePropertyError {
+    // @internal This exception should only be constructed by this package itself
+    public constructor(
+        template: HalFormsTemplate<any>,
+        property: HalFormsProperty
+    ) {
+        super(template, property, `type "${property.type}" is not supported by this codec`);
+        Object.setPrototypeOf(this, new.target.prototype);
+        this.name = HalFormsCodecPropertyTypeNotSupportedError.name;
+    }
+
 }

--- a/packages/hal-forms/src/codecs/impl.ts
+++ b/packages/hal-forms/src/codecs/impl.ts
@@ -91,4 +91,5 @@ export default class HalFormsCodecsBuilderImpl extends AbstractHalFormsCodecs im
         }
         return null;
     }
+
 }

--- a/packages/hal-forms/src/codecs/impl.ts
+++ b/packages/hal-forms/src/codecs/impl.ts
@@ -2,8 +2,8 @@ import { TypedRequest, TypedRequestSpec } from "@contentgrid/typed-fetch";
 import { HalFormsTemplate } from "..";
 import { HalFormsCodec, HalFormsCodecMatcher, HalFormsCodecs, HalFormsCodecsBuilder, HalFormsCodecsMatchers } from "./api";
 import { HalFormsEncoder } from "./encoders/api";
-import { AnyHalFormValue } from "../values/api";
 import { HalFormsCodecNotAvailableError, HalFormsCodecPropertyTypeNotSupportedError } from "./errors";
+import { HalFormValues, HalFormValuesMap, createValues } from "../values";
 
 abstract class AbstractHalFormsCodecs implements HalFormsCodecs {
     abstract findCodecFor<T, R>(template: HalFormsTemplate<TypedRequestSpec<T, R>>): HalFormsCodec<T, R> | null;
@@ -49,8 +49,12 @@ export class HalFormsCodecImpl<T, R> implements HalFormsCodec<T, R> {
 
     }
 
-    public encode(values: readonly AnyHalFormValue[]): TypedRequest<T, R> {
-        return this.encoder.encode(this.template, values);
+    public encode(values: HalFormValuesMap | HalFormValues<TypedRequest<T, R>>): TypedRequest<T, R> {
+        if(!HalFormValues.isInstance(values)) {
+            values = createValues(this.template)
+                .withValues(values);
+        }
+        return this.encoder.encode(this.template, values.values);
     }
 
 }

--- a/packages/hal-forms/src/codecs/index.ts
+++ b/packages/hal-forms/src/codecs/index.ts
@@ -3,7 +3,7 @@ export * from "./errors";
 export * as Encoders from "./encoders";
 
 import { HalFormsCodecs, HalFormsCodecsMatchers } from "./api";
-import { nestedJson } from "./encoders";
+import { multipartForm, nestedJson, uriList, urlencodedForm } from "./encoders";
 
 /**
  * Default HAL-FORMS codecs
@@ -17,4 +17,7 @@ export default HalFormsCodecs.builder()
         nestedJson()
     )
     .registerEncoder("application/json", nestedJson())
+    .registerEncoder("text/uri-list", uriList())
+    .registerEncoder("multipart/form-data", multipartForm())
+    .registerEncoder("application/x-www-form-urlencoded", urlencodedForm())
     .build();

--- a/packages/hal-forms/src/codecs/index.ts
+++ b/packages/hal-forms/src/codecs/index.ts
@@ -3,7 +3,7 @@ export * from "./errors";
 export * as Encoders from "./encoders";
 
 import { HalFormsCodecs, HalFormsCodecsMatchers } from "./api";
-import { multipartForm, nestedJson, uriList, urlencodedForm } from "./encoders";
+import { multipartForm, nestedJson, uriList, urlencodedForm, urlencodedQuerystring } from "./encoders";
 
 /**
  * Default HAL-FORMS codecs
@@ -15,6 +15,10 @@ export default HalFormsCodecs.builder()
             HalFormsCodecsMatchers.encodedToRequestBody()
         ),
         nestedJson()
+    )
+    .registerEncoder(
+        HalFormsCodecsMatchers.encodedToRequestUrl(),
+        urlencodedQuerystring()
     )
     .registerEncoder("application/json", nestedJson())
     .registerEncoder("text/uri-list", uriList())

--- a/packages/hal-forms/src/values/api.ts
+++ b/packages/hal-forms/src/values/api.ts
@@ -1,6 +1,7 @@
 import { TypedRequestSpec } from "@contentgrid/typed-fetch";
 import { HalFormsProperty } from "../api";
 import { HalFormsPropertyType } from "../_shape";
+import { HalFormValuesImpl } from "./impl";
 
 /**
  * Value manager for a HAL-FORMS template
@@ -58,6 +59,11 @@ export interface HalFormValues<RS extends TypedRequestSpec<any, any>> {
     withValues(values: HalFormValuesMap): HalFormValues<RS>;
 }
 
+export namespace HalFormValues {
+    export function isInstance(object: any): object is HalFormValues<any> {
+        return object instanceof HalFormValuesImpl;
+    }
+}
 
 /**
  * A value for a HAL-FORMS property of a certain type

--- a/packages/hal-forms/src/values/api.ts
+++ b/packages/hal-forms/src/values/api.ts
@@ -17,6 +17,11 @@ export interface HalFormValues<RS extends TypedRequestSpec<any, any>> {
     readonly values: readonly AnyHalFormValue[];
 
     /**
+     * Object mapping HAL-FORMS property names to their respective value
+     */
+    readonly valueMap: HalFormValuesMap;
+
+    /**
      * Retrieve the value for a specific named HAL-FORMS property
      *
      * @param propertyName - The name of the HAL-FORMS property to retrieve a value for
@@ -50,7 +55,7 @@ export interface HalFormValues<RS extends TypedRequestSpec<any, any>> {
      * @param values - Mapping of HAL-FORMS property names to their new values
      * @return New value manager with the specified properties updated to their new values
      */
-    withValues(values: { [propertyName: string]: DefinedHalFormValue["value"] }): HalFormValues<RS>;
+    withValues(values: HalFormValuesMap): HalFormValues<RS>;
 }
 
 
@@ -94,3 +99,8 @@ export interface UndefinedHalFormValue {
  * A HAL-FORMS property that can either have a value or not have one
  */
 export type AnyHalFormValue = DefinedHalFormValue | UndefinedHalFormValue;
+
+/**
+ * Object mapping HAL-FORMS property names to their respective value
+ */
+export type HalFormValuesMap = Readonly<Record<string, DefinedHalFormValue["value"]>>;

--- a/packages/hal-forms/src/values/api.ts
+++ b/packages/hal-forms/src/values/api.ts
@@ -85,7 +85,10 @@ export type DefinedHalFormValue = SpecificTypesHalFormValue | StringTypesHalForm
 /**
  * A HAL-FORMS property that does not have any value
  */
-export type UndefinedHalFormValue = TypedHalFormValue<HalFormsPropertyType, undefined>;
+export interface UndefinedHalFormValue {
+    readonly property: HalFormsProperty;
+    readonly value: undefined;
+}
 
 /**
  * A HAL-FORMS property that can either have a value or not have one

--- a/packages/hal-forms/src/values/impl.ts
+++ b/packages/hal-forms/src/values/impl.ts
@@ -32,6 +32,12 @@ export class HalFormValuesImpl<RS extends TypedRequestSpec<any, any>> implements
         return this.template.properties.map(property => this.value(property.name));
     }
 
+    public get valueMap() {
+        return Object.fromEntries(this.values
+            .filter(v => v.value !== undefined)
+            .map(v => [v.property.name, v.value!]));
+    }
+
     public value(propertyName: string): AnyHalFormValue {
         const property = this.template.property(propertyName);
         const value = this.valueMapping[property.name];

--- a/packages/typed-fetch/src/representation.ts
+++ b/packages/typed-fetch/src/representation.ts
@@ -4,8 +4,12 @@ export type RepresentationOf<T> = RequestInit["body"] & {
     [_representationType]: T
 };
 
+export function createUnsafe<T>(body: RequestInit["body"]): RepresentationOf<T> {
+    return body as RepresentationOf<T>;
+}
+
 type Tail<T extends any[]> = T extends [infer _A, ...infer R] ? R : never;
 
 export function json<T>(value: T, ...args: Tail<Parameters<typeof JSON.stringify>>): RepresentationOf<T> {
-    return JSON.stringify(value, ...args) as RepresentationOf<T>;
+    return createUnsafe(JSON.stringify(value, ...args));
 }


### PR DESCRIPTION
1. Add check that encoder supports all HAL-FORM field types
    Most encoders do not actually support encoding files; so instead of creating a broken JSON object or omitting the field, immediately fail while selecting the encoder, so failure is not dependent on the user-entered data
2. Test that the json encoder sets the requested content-type header in the HAL-FORMS template, instead of application/json
3. Add `HalFormValues#valueMap`: A shortcut to retrieve an object simply mapping propertyName to the value directly
4. Make using `HalFormsCodec#encode()` easier by allowing `HalFormValues` or its valueMap being passed.
5. Add form and uri-list encoders
6. Add encoding GET requests

