### PR TITLE
ACC-1450: Create fetch-hook-authentication package

### DIFF
--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -139,7 +139,9 @@ const config = {
   // setupFiles: [],
 
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  setupFilesAfterEnv: [
+    "jest-extended/all"
+  ],
 
   // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -32,7 +32,10 @@
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": [                                           /* Specify type package names to be included without being referenced in a source file. */
+      "jest",
+      "jest-extended"
+    ],
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */

--- a/package.json
+++ b/package.json
@@ -17,12 +17,15 @@
     "@jest/globals": "^29.6.2",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-typescript": "^11.1.2",
+    "@types/jest": "^29.5.12",
     "glob": "^10.3.10",
     "jest": "^29.6.2",
+    "jest-extended": "^4.0.2",
     "lerna": "^8.0.0",
     "rollup": "^4.0.0",
     "rollup-plugin-clear": "^2.0.7",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/fetch-hook-authentication/README.md
+++ b/packages/fetch-hook-authentication/README.md
@@ -1,0 +1,3 @@
+# `@contentgrid/fetch-hook-authentication`
+
+[Fetch hook](../fetch-hooks/) to perform Bearer token authentication

--- a/packages/fetch-hook-authentication/__tests__/index.ts
+++ b/packages/fetch-hook-authentication/__tests__/index.ts
@@ -1,0 +1,37 @@
+import createBearerAuthenticationHook from "../src"
+
+test("injects authorization header when token supplied", async () => {
+    const hook = createBearerAuthenticationHook({
+        tokenSupplier: async (uri) => ({ token: "token-" + uri, expiresAt: null })
+    });
+
+    const fakeFetch = jest.fn(async (..._args: Parameters<typeof fetch>) => new Response("", { status: 200 }));
+
+    const hookedFetch = hook(fakeFetch);
+
+    await hookedFetch("http://example.com/xyz");
+
+    const request = fakeFetch.mock.lastCall?.[0] as Request;
+
+    expect(request).toBeInstanceOf(Request)
+    expect(request.headers.get("authorization")).toEqual("Bearer token-http://example.com/xyz")
+
+});
+
+test("ignores authorization header when notoken supplied", async () => {
+    const hook = createBearerAuthenticationHook({
+        tokenSupplier: async () => null
+    });
+
+    const fakeFetch = jest.fn(async (..._args: Parameters<typeof fetch>) => new Response("", { status: 200 }));
+
+    const hookedFetch = hook(fakeFetch);
+
+    await hookedFetch("http://example.com/xyz");
+
+    const request = fakeFetch.mock.lastCall?.[0] as Request;
+
+    expect(request).toBeInstanceOf(Request)
+    expect(request.headers.has("authorization")).toBeFalse();
+
+});

--- a/packages/fetch-hook-authentication/__tests__/index.ts
+++ b/packages/fetch-hook-authentication/__tests__/index.ts
@@ -1,8 +1,9 @@
+import { ValueProviderResolver } from "@contentgrid/fetch-hooks/value-provider";
 import createBearerAuthenticationHook from "../src"
 
 test("injects authorization header when token supplied", async () => {
     const hook = createBearerAuthenticationHook({
-        tokenSupplier: async (uri) => ({ token: "token-" + uri, expiresAt: null })
+        tokenSupplier: ValueProviderResolver.constant(async (uri) => ({ token: "token-" + uri, expiresAt: null }))
     });
 
     const fakeFetch = jest.fn(async (..._args: Parameters<typeof fetch>) => new Response("", { status: 200 }));
@@ -20,7 +21,7 @@ test("injects authorization header when token supplied", async () => {
 
 test("ignores authorization header when notoken supplied", async () => {
     const hook = createBearerAuthenticationHook({
-        tokenSupplier: async () => null
+        tokenSupplier: ValueProviderResolver.constant(async () => null)
     });
 
     const fakeFetch = jest.fn(async (..._args: Parameters<typeof fetch>) => new Response("", { status: 200 }));

--- a/packages/fetch-hook-authentication/__tests__/token-supplier/composite.ts
+++ b/packages/fetch-hook-authentication/__tests__/token-supplier/composite.ts
@@ -1,0 +1,32 @@
+import { CompositeTokenSupplierBuilder } from "../../src/token-supplier/composite";
+import { AuthenticationTokenSupplier } from "../../src/token-supplier";
+
+function createFakeTokenSupplier(token: string): AuthenticationTokenSupplier {
+    return async () => ({
+        token,
+        expiresAt: null
+    });
+}
+
+test("composite without fallback", async () => {
+    const compositeSupplier = new CompositeTokenSupplierBuilder()
+        .origin("http://example.com", createFakeTokenSupplier("example.com-token"))
+        .origin("http://example.org", createFakeTokenSupplier("example.org-token"))
+        .build()
+
+    expect(compositeSupplier("http://example.com/abc/def")).resolves.toEqual({ token: "example.com-token", expiresAt: null });
+    expect(compositeSupplier("http://example.org/zzzz")).resolves.toEqual({token: "example.org-token", expiresAt: null});
+    expect(compositeSupplier("http://example.net/")).resolves.toBeNull();
+
+})
+
+test("composite with fallback", async () => {
+    const compositeSupplier = new CompositeTokenSupplierBuilder()
+        .origin("http://example.com", createFakeTokenSupplier("example.com-token"))
+        .default(createFakeTokenSupplier("default-token"))
+        .build()
+
+    expect(compositeSupplier("http://example.com/abc/def")).resolves.toEqual({ token: "example.com-token", expiresAt: null });
+    expect(compositeSupplier("http://example.org/zzzz")).resolves.toEqual({ token: "default-token", expiresAt: null });
+
+})

--- a/packages/fetch-hook-authentication/__tests__/token-supplier/composite.ts
+++ b/packages/fetch-hook-authentication/__tests__/token-supplier/composite.ts
@@ -8,15 +8,19 @@ function createFakeTokenSupplier(token: string): AuthenticationTokenSupplier {
     });
 }
 
+const supplierOpts = {
+    fetch: jest.fn()
+}
+
 test("composite without fallback", async () => {
     const compositeSupplier = new CompositeTokenSupplierBuilder()
         .origin("http://example.com", createFakeTokenSupplier("example.com-token"))
         .origin("http://example.org", createFakeTokenSupplier("example.org-token"))
         .build()
 
-    expect(compositeSupplier("http://example.com/abc/def")).resolves.toEqual({ token: "example.com-token", expiresAt: null });
-    expect(compositeSupplier("http://example.org/zzzz")).resolves.toEqual({token: "example.org-token", expiresAt: null});
-    expect(compositeSupplier("http://example.net/")).resolves.toBeNull();
+    expect(compositeSupplier("http://example.com/abc/def", supplierOpts)).resolves.toEqual({ token: "example.com-token", expiresAt: null });
+    expect(compositeSupplier("http://example.org/zzzz", supplierOpts)).resolves.toEqual({token: "example.org-token", expiresAt: null});
+    expect(compositeSupplier("http://example.net/", supplierOpts)).resolves.toBeNull();
 
 })
 
@@ -26,7 +30,7 @@ test("composite with fallback", async () => {
         .default(createFakeTokenSupplier("default-token"))
         .build()
 
-    expect(compositeSupplier("http://example.com/abc/def")).resolves.toEqual({ token: "example.com-token", expiresAt: null });
-    expect(compositeSupplier("http://example.org/zzzz")).resolves.toEqual({ token: "default-token", expiresAt: null });
+    expect(compositeSupplier("http://example.com/abc/def", supplierOpts)).resolves.toEqual({ token: "example.com-token", expiresAt: null });
+    expect(compositeSupplier("http://example.org/zzzz", supplierOpts)).resolves.toEqual({ token: "default-token", expiresAt: null });
 
 })

--- a/packages/fetch-hook-authentication/__tests__/token-supplier/contentGridTokenExchange.ts
+++ b/packages/fetch-hook-authentication/__tests__/token-supplier/contentGridTokenExchange.ts
@@ -1,0 +1,166 @@
+import { createContentgridTokenExchangeTokenSupplier } from "../../src/token-supplier";
+import { OAuth2AuthenticationError, TokenExchangeProtocolViolationError } from "../../src/token-supplier/contentgridTokenExchange";
+
+test("successful token exchange", async () => {
+    const fakeFetch = jest.fn(async () => new Response(JSON.stringify({
+        access_token: "my-access-token",
+        token_type: "BeaRer", // should be case-insensitive match
+        expires_in: 135
+    }), {
+        status: 200,
+        headers: {
+            "content-type": "application/json"
+        }
+    }));
+
+    const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
+        exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
+        fetch: fakeFetch
+    });
+
+    const token = await tokenSupplier("https://example.com/xyz");
+    expect(token?.token).toEqual("my-access-token");
+    expect(token?.expiresAt).toBeBetween(new Date(Date.now() + 134_000), new Date(Date.now() + 135_000));
+})
+
+test("successful token exchange without expiry", async () => {
+    const fakeFetch = jest.fn(async () => new Response(JSON.stringify({
+        access_token: "my-access-token",
+        token_type: "BeaRer", // should be case-insensitive match
+    }), {
+        status: 200,
+        headers: {
+            "content-type": "application/json"
+        }
+    }));
+
+    const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
+        exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
+        fetch: fakeFetch
+    });
+
+    const token = await tokenSupplier("https://example.com/xyz");
+    expect(token?.token).toEqual("my-access-token");
+    expect(token?.expiresAt).toBeNull();
+})
+
+test("successful token exchange without token_type parameter", async () => {
+    const fakeFetch = jest.fn(async () => new Response(JSON.stringify({
+        access_token: "my-access-token"
+    }), {
+        status: 200,
+        headers: {
+            "content-type": "application/json"
+        }
+    }));
+
+    const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
+        exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
+        fetch: fakeFetch
+    });
+
+    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+})
+
+test("successful token exchange without access_token parameter", async () => {
+    const fakeFetch = jest.fn(async () => new Response(JSON.stringify({
+        token_type: "BeaRer", // should be case-insensitive match
+    }), {
+        status: 200,
+        headers: {
+            "content-type": "application/json"
+        }
+    }));
+
+    const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
+        exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
+        fetch: fakeFetch
+    });
+
+    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+})
+
+test("successful token exchange with unsupported token_type", async () => {
+    const fakeFetch = jest.fn(async () => new Response(JSON.stringify({
+        access_token: "my-access-token",
+        token_type: "mac",
+        expires_in: 135
+    }), {
+        status: 200,
+        headers: {
+            "content-type": "application/json"
+        }
+    }));
+
+    const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
+        exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
+        fetch: fakeFetch
+    });
+
+    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+})
+
+test("successful token exchange with non-json response", async () => {
+    const fakeFetch = jest.fn(async () => new Response("", {
+        status: 200,
+    }));
+
+    const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
+        exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
+        fetch: fakeFetch
+    });
+
+    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+})
+
+test("failed token exchange with OAuth error", async () => {
+    const fakeFetch = jest.fn(async () => new Response(JSON.stringify({
+        error: "invalid_request",
+        error_description: "You did something wrong"
+
+    }), {
+        status: 400,
+        headers: {
+            "content-type": "application/json"
+        }
+    }));
+
+    const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
+        exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
+        fetch: fakeFetch
+    });
+
+    expect(tokenSupplier("https://example.com/xyz")).rejects.toEqual(new OAuth2AuthenticationError("invalid_request", "You did something wrong"));
+})
+
+test("failed token exchange with non-OAuth JSON error", async () => {
+    const fakeFetch = jest.fn(async () => new Response("{}", {
+        status: 400,
+        headers: {
+            "content-type": "application/json"
+        }
+    }));
+
+    const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
+        exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
+        fetch: fakeFetch
+    });
+
+    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+})
+
+test("failed token exchange with non-OAuth error", async () => {
+    const fakeFetch = jest.fn(async () => new Response("<<<<<", {
+        status: 400,
+        headers: {
+            "content-type": "text/html"
+        }
+    }));
+
+    const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
+        exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
+        fetch: fakeFetch
+    });
+
+    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+})

--- a/packages/fetch-hook-authentication/__tests__/token-supplier/contentGridTokenExchange.ts
+++ b/packages/fetch-hook-authentication/__tests__/token-supplier/contentGridTokenExchange.ts
@@ -15,10 +15,11 @@ test("successful token exchange", async () => {
 
     const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
         exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
-        fetch: fakeFetch
     });
 
-    const token = await tokenSupplier("https://example.com/xyz");
+    const token = await tokenSupplier("https://example.com/xyz", {
+        fetch: fakeFetch
+    });
     expect(token?.token).toEqual("my-access-token");
     expect(token?.expiresAt).toBeBetween(new Date(Date.now() + 134_000), new Date(Date.now() + 135_000));
 })
@@ -36,10 +37,11 @@ test("successful token exchange without expiry", async () => {
 
     const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
         exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
-        fetch: fakeFetch
     });
 
-    const token = await tokenSupplier("https://example.com/xyz");
+    const token = await tokenSupplier("https://example.com/xyz", {
+        fetch: fakeFetch
+    });
     expect(token?.token).toEqual("my-access-token");
     expect(token?.expiresAt).toBeNull();
 })
@@ -56,10 +58,11 @@ test("successful token exchange without token_type parameter", async () => {
 
     const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
         exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
-        fetch: fakeFetch
     });
 
-    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+    expect(tokenSupplier("https://example.com/xyz", {
+        fetch: fakeFetch
+    })).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
 })
 
 test("successful token exchange without access_token parameter", async () => {
@@ -74,10 +77,11 @@ test("successful token exchange without access_token parameter", async () => {
 
     const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
         exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
-        fetch: fakeFetch
     });
 
-    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+    expect(tokenSupplier("https://example.com/xyz", {
+        fetch: fakeFetch
+    })).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
 })
 
 test("successful token exchange with unsupported token_type", async () => {
@@ -94,10 +98,11 @@ test("successful token exchange with unsupported token_type", async () => {
 
     const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
         exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
-        fetch: fakeFetch
     });
 
-    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+    expect(tokenSupplier("https://example.com/xyz", {
+        fetch: fakeFetch
+    })).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
 })
 
 test("successful token exchange with non-json response", async () => {
@@ -107,10 +112,11 @@ test("successful token exchange with non-json response", async () => {
 
     const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
         exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
-        fetch: fakeFetch
     });
 
-    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+    expect(tokenSupplier("https://example.com/xyz", {
+        fetch: fakeFetch
+    })).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
 })
 
 test("failed token exchange with OAuth error", async () => {
@@ -127,10 +133,11 @@ test("failed token exchange with OAuth error", async () => {
 
     const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
         exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
-        fetch: fakeFetch
     });
 
-    expect(tokenSupplier("https://example.com/xyz")).rejects.toEqual(new OAuth2AuthenticationError("invalid_request", "You did something wrong"));
+    expect(tokenSupplier("https://example.com/xyz", {
+        fetch: fakeFetch
+    })).rejects.toEqual(new OAuth2AuthenticationError("invalid_request", "You did something wrong"));
 })
 
 test("failed token exchange with non-OAuth JSON error", async () => {
@@ -143,10 +150,11 @@ test("failed token exchange with non-OAuth JSON error", async () => {
 
     const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
         exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
-        fetch: fakeFetch
     });
 
-    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+    expect(tokenSupplier("https://example.com/xyz", {
+        fetch: fakeFetch
+    })).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
 })
 
 test("failed token exchange with non-OAuth error", async () => {
@@ -159,8 +167,9 @@ test("failed token exchange with non-OAuth error", async () => {
 
     const tokenSupplier = createContentgridTokenExchangeTokenSupplier({
         exchangeUrl: "https://extensions.contentgrid.example/exchange/token",
-        fetch: fakeFetch
     });
 
-    expect(tokenSupplier("https://example.com/xyz")).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
+    expect(tokenSupplier("https://example.com/xyz", {
+        fetch: fakeFetch
+    })).rejects.toBeInstanceOf(TokenExchangeProtocolViolationError);
 })

--- a/packages/fetch-hook-authentication/babel.config.mjs
+++ b/packages/fetch-hook-authentication/babel.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../config/babel.config.mjs";

--- a/packages/fetch-hook-authentication/jest.config.js
+++ b/packages/fetch-hook-authentication/jest.config.js
@@ -1,0 +1,1 @@
+module.exports = require('../../config/jest.config.js');

--- a/packages/fetch-hook-authentication/package.json
+++ b/packages/fetch-hook-authentication/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@contentgrid/fetch-hook-authentication",
+  "version": "0.0.1-alpha.0",
+  "description": "",
+  "keywords": [
+    "fetch",
+    "typescript",
+    "hooks",
+    "fetch-hook"
+  ],
+  "main": "./build/index.js",
+  "module": "./build/index.mjs",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
+      "default": "./build/index.js"
+    }
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@babel/runtime": "^7.22.10",
+    "@contentgrid/fetch-hooks": "^0.0.1-alpha.0",
+    "@types/whatwg-mimetype": "^3.0.2",
+    "tslib": "^2.6.1",
+    "whatwg-mimetype": "^4.0.0"
+  },
+  "scripts": {
+    "prepare": "rollup -c",
+    "test": "jest"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "build"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/xenit-eu/contentgrid-ts.git",
+    "directory": "packages/fetch-hook-authentication"
+  },
+  "devDependencies": {}
+}

--- a/packages/fetch-hook-authentication/rollup.config.mjs
+++ b/packages/fetch-hook-authentication/rollup.config.mjs
@@ -1,0 +1,1 @@
+export { default } from "../../config/rollup.config.mjs";

--- a/packages/fetch-hook-authentication/src/index.ts
+++ b/packages/fetch-hook-authentication/src/index.ts
@@ -10,7 +10,7 @@ interface AuthenticationTokenHookOptions {
 
 
 export default function createBearerAuthenticationHook(opts: AuthenticationTokenHookOptions): FetchHook {
-    const tokenSupplierResolver = ValueProviderResolver.cached(ValueProviderResolver.fromValueProvider(opts.tokenSupplier));
+    const tokenSupplierResolver = ValueProviderResolver.fromValueProvider(opts.tokenSupplier);
     return setHeader("Authorization", async ({ request, entrypoint }) => {
         const tokenSupplier = await tokenSupplierResolver.resolve();
         const authenticationToken = await tokenSupplier(request.url, { signal: request.signal, fetch: entrypoint });

--- a/packages/fetch-hook-authentication/src/index.ts
+++ b/packages/fetch-hook-authentication/src/index.ts
@@ -9,8 +9,8 @@ interface AuthenticationTokenHookOptions {
 
 
 export default function createBearerAuthenticationHook(opts: AuthenticationTokenHookOptions): FetchHook {
-    return setHeader("Authorization", async ({ request }) => {
-        const authenticationToken = await opts.tokenSupplier(request.url, { signal: request.signal });
+    return setHeader("Authorization", async ({ request, entrypoint }) => {
+        const authenticationToken = await opts.tokenSupplier(request.url, { signal: request.signal, fetch: entrypoint });
         if(authenticationToken) {
             return "Bearer " + authenticationToken.token;
         } else {

--- a/packages/fetch-hook-authentication/src/index.ts
+++ b/packages/fetch-hook-authentication/src/index.ts
@@ -1,0 +1,20 @@
+import { FetchHook } from "@contentgrid/fetch-hooks";
+import { setHeader } from "@contentgrid/fetch-hooks/request";
+import { AuthenticationTokenSupplier } from "./token-supplier";
+export * from "./token-supplier";
+
+interface AuthenticationTokenHookOptions {
+    tokenSupplier: AuthenticationTokenSupplier;
+}
+
+
+export default function createBearerAuthenticationHook(opts: AuthenticationTokenHookOptions): FetchHook {
+    return setHeader("Authorization", async ({ request }) => {
+        const authenticationToken = await opts.tokenSupplier(request.url, { signal: request.signal });
+        if(authenticationToken) {
+            return "Bearer " + authenticationToken.token;
+        } else {
+            return null;
+        }
+    })
+}

--- a/packages/fetch-hook-authentication/src/index.ts
+++ b/packages/fetch-hook-authentication/src/index.ts
@@ -1,16 +1,19 @@
 import { FetchHook } from "@contentgrid/fetch-hooks";
 import { setHeader } from "@contentgrid/fetch-hooks/request";
 import { AuthenticationTokenSupplier } from "./token-supplier";
+import { ValueProvider, ValueProviderResolver } from "@contentgrid/fetch-hooks/value-provider";
 export * from "./token-supplier";
 
 interface AuthenticationTokenHookOptions {
-    tokenSupplier: AuthenticationTokenSupplier;
+    tokenSupplier: ValueProvider<AuthenticationTokenSupplier, []>;
 }
 
 
 export default function createBearerAuthenticationHook(opts: AuthenticationTokenHookOptions): FetchHook {
+    const tokenSupplierResolver = ValueProviderResolver.cached(ValueProviderResolver.fromValueProvider(opts.tokenSupplier));
     return setHeader("Authorization", async ({ request, entrypoint }) => {
-        const authenticationToken = await opts.tokenSupplier(request.url, { signal: request.signal, fetch: entrypoint });
+        const tokenSupplier = await tokenSupplierResolver.resolve();
+        const authenticationToken = await tokenSupplier(request.url, { signal: request.signal, fetch: entrypoint });
         if(authenticationToken) {
             return "Bearer " + authenticationToken.token;
         } else {

--- a/packages/fetch-hook-authentication/src/token-supplier/composite.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/composite.ts
@@ -1,0 +1,50 @@
+import { AuthenticationTokenSupplier } from "./types";
+
+type UriPredicate = (uri: string) => boolean;
+
+interface SupplierEntry {
+    predicate: UriPredicate;
+    supplier: AuthenticationTokenSupplier;
+}
+
+export default function createCompositeTokenSupplier(suppliers: readonly SupplierEntry[]): AuthenticationTokenSupplier {
+    return async (uri, opts) => {
+        for(const supplier of suppliers) {
+            if(supplier.predicate(uri)) {
+                return await supplier.supplier(uri, opts);
+            }
+        }
+        return null;
+    }
+}
+
+export class CompositeTokenSupplierBuilder {
+
+    public constructor();
+    /* @internal */
+    public constructor(suppliers: readonly SupplierEntry[]);
+    public constructor(
+        private readonly suppliers: readonly SupplierEntry[] = []
+    ) {
+
+    }
+
+    public predicate(predicate: UriPredicate, supplier: AuthenticationTokenSupplier): CompositeTokenSupplierBuilder {
+        return new CompositeTokenSupplierBuilder(this.suppliers.concat([{ predicate, supplier }]))
+    }
+
+    public origin(origin: string, supplier: AuthenticationTokenSupplier): CompositeTokenSupplierBuilder {
+        return this.predicate(uri => {
+            return new URL(uri).origin === origin
+        }, supplier);
+    }
+
+    public default(supplier: AuthenticationTokenSupplier): CompositeTokenSupplierBuilder {
+        return this.predicate(() => true, supplier);
+    }
+
+    public build(): AuthenticationTokenSupplier {
+        return createCompositeTokenSupplier(this.suppliers);
+    }
+
+}

--- a/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
@@ -1,10 +1,11 @@
 import { FetchHooksError } from "@contentgrid/fetch-hooks";
 import { AuthenticationToken, AuthenticationTokenSupplier } from "./types";
 import MimeType from "whatwg-mimetype";
+import { ValueProvider, ValueProviderResolver } from "@contentgrid/fetch-hooks/value-provider";
 
 
 interface TokenExchangeConfiguration {
-    exchangeUrl: string;
+    exchangeUrl: ValueProvider<string, []>;
 }
 
 function createTokenRequestBody(resource: string): URLSearchParams {
@@ -58,8 +59,10 @@ function createOAuth2Error(responseBody: any): OAuth2AuthenticationError | null 
 }
 
 export default function createContentgridTokenExchangeTokenSupplier(config: TokenExchangeConfiguration): AuthenticationTokenSupplier {
+    const exchangeUrlResolver = ValueProviderResolver.cached(ValueProviderResolver.fromValueProvider(config.exchangeUrl));
     return async (uri, opts) => {
-        const response = await opts.fetch(config.exchangeUrl, {
+        const exchangeUrl = await exchangeUrlResolver.resolve();
+        const response = await opts.fetch(exchangeUrl, {
             signal: opts?.signal ?? null,
             method: "POST",
             body: createTokenRequestBody(uri)

--- a/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
@@ -5,7 +5,7 @@ import { ValueProvider, ValueProviderResolver } from "@contentgrid/fetch-hooks/v
 
 
 interface TokenExchangeConfiguration {
-    exchangeUrl: ValueProvider<string, []>;
+    exchangeUrl: ValueProvider<string, [{ fetch: typeof fetch }]>;
 }
 
 function createTokenRequestBody(resource: string): URLSearchParams {
@@ -61,7 +61,7 @@ function createOAuth2Error(responseBody: any): OAuth2AuthenticationError | null 
 export default function createContentgridTokenExchangeTokenSupplier(config: TokenExchangeConfiguration): AuthenticationTokenSupplier {
     const exchangeUrlResolver = ValueProviderResolver.cached(ValueProviderResolver.fromValueProvider(config.exchangeUrl));
     return async (uri, opts) => {
-        const exchangeUrl = await exchangeUrlResolver.resolve();
+        const exchangeUrl = await exchangeUrlResolver.resolve(opts);
         const response = await opts.fetch(exchangeUrl, {
             signal: opts?.signal ?? null,
             method: "POST",

--- a/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
@@ -59,7 +59,7 @@ function createOAuth2Error(responseBody: any): OAuth2AuthenticationError | null 
 }
 
 export default function createContentgridTokenExchangeTokenSupplier(config: TokenExchangeConfiguration): AuthenticationTokenSupplier {
-    const exchangeUrlResolver = ValueProviderResolver.cached(ValueProviderResolver.fromValueProvider(config.exchangeUrl));
+    const exchangeUrlResolver = ValueProviderResolver.fromValueProvider(config.exchangeUrl);
     return async (uri, opts) => {
         const exchangeUrl = await exchangeUrlResolver.resolve(opts);
         const response = await opts.fetch(exchangeUrl, {

--- a/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
@@ -44,7 +44,7 @@ function isJsonContentType(contentType: string | null): boolean {
     const mimetype = new MimeType(contentType);
 
     // https://mimesniff.spec.whatwg.org/#json-mime-type
-    return (mimetype.type === "application" || mimetype.type === "text") && (mimetype.subtype === "json" || mimetype.subtype.endsWith("+json"));
+    return ((mimetype.type === "application" || mimetype.type === "text") && mimetype.subtype === "json") || mimetype.subtype.endsWith("+json");
 
 }
 

--- a/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
@@ -1,0 +1,119 @@
+import { FetchHooksError } from "@contentgrid/fetch-hooks";
+import { AuthenticationToken, AuthenticationTokenSupplier } from "./types";
+import MimeType from "whatwg-mimetype";
+
+type Fetch = typeof fetch;
+
+
+interface TokenExchangeConfiguration {
+    fetch: Fetch,
+    exchangeUrl: string;
+}
+
+function createTokenRequestBody(resource: string): URLSearchParams {
+    const formData = new URLSearchParams();
+    formData.append("grant_type", "https://contentgrid.cloud/oauth2/grant/extension-token");
+    formData.append("resource", resource);
+    return formData;
+}
+
+
+function createAuthenticationToken(responseBody: any): AuthenticationToken {
+    // Verify response validity: https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
+    if(!("token_type" in responseBody)) {
+        throw new TokenExchangeProtocolViolationError(`Missing 'token_type' in response`);
+    }
+    if(!("access_token" in responseBody)) {
+        throw new TokenExchangeProtocolViolationError(`Missing 'access_token' in response`);
+    }
+
+    if(String(responseBody["token_type"]).toLowerCase() !== "bearer") {
+        throw new TokenExchangeProtocolViolationError(`Unsupported token type ${responseBody["token_type"]}`);
+    }
+
+    const expiry = "expires_in" in responseBody ? new Date(Date.now() + responseBody["expires_in"] * 1000) : null;
+
+    return {
+        token: responseBody["access_token"],
+        expiresAt: expiry
+    };
+}
+
+function isJsonContentType(contentType: string | null): boolean {
+    if(!contentType) {
+        return false;
+    }
+    const mimetype = new MimeType(contentType);
+
+    // https://mimesniff.spec.whatwg.org/#json-mime-type
+    return (mimetype.type === "application" || mimetype.type === "text") && (mimetype.subtype === "json" || mimetype.subtype.endsWith("+json"));
+
+}
+
+function createOAuth2Error(responseBody: any): OAuth2AuthenticationError | null {
+    if(!("error" in responseBody)) {
+        return null; // 'error' field is required in OAuth error responses: https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+    }
+    return new OAuth2AuthenticationError(
+        responseBody["error"],
+        responseBody["error_description"]
+    );
+}
+
+export default function createContentgridTokenExchangeTokenSupplier(config: TokenExchangeConfiguration): AuthenticationTokenSupplier {
+    return async (uri, opts) => {
+        const response = await config.fetch(config.exchangeUrl, {
+            signal: opts?.signal ?? null,
+            method: "POST",
+            body: createTokenRequestBody(uri)
+        })
+
+        if(response.ok) {
+            if(isJsonContentType(response.headers.get("content-type"))) {
+                return createAuthenticationToken(await response.json());
+            } else {
+                throw new TokenExchangeProtocolViolationError(`Content type ${response.headers.get('content-type')} is not JSON`);
+            }
+        } else {
+            if(isJsonContentType(response.headers.get("content-type"))) {
+                const oauthError = createOAuth2Error(await response.json());
+                if(oauthError) {
+                    throw oauthError;
+                }
+            }
+            throw new TokenExchangeProtocolViolationError(`Non-OAuth response error: ${response.status} ${response.statusText}`);
+        }
+    }
+
+}
+
+/**
+ * Base class for token exchange errors
+ */
+export class TokenExchangeError extends FetchHooksError {
+    public constructor(message: string) {
+        super(`Token exchange failed: ${message}`)
+    }
+}
+
+/**
+ * Unexpected deviation from the expected token exchange flow
+ */
+export class TokenExchangeProtocolViolationError extends TokenExchangeError {
+    public constructor(message: string) {
+        super(`Protocol violation: ${message}`)
+    }
+}
+
+/**
+ * A potentially-expected OAuth error response
+ */
+export class OAuth2AuthenticationError extends TokenExchangeError {
+    public constructor(
+        public readonly code: string,
+        public readonly description: string,
+    ) {
+        super(`OAuth2 error ${code}: ${description}`)
+    }
+
+}

--- a/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/contentgridTokenExchange.ts
@@ -2,11 +2,8 @@ import { FetchHooksError } from "@contentgrid/fetch-hooks";
 import { AuthenticationToken, AuthenticationTokenSupplier } from "./types";
 import MimeType from "whatwg-mimetype";
 
-type Fetch = typeof fetch;
-
 
 interface TokenExchangeConfiguration {
-    fetch: Fetch,
     exchangeUrl: string;
 }
 
@@ -62,7 +59,7 @@ function createOAuth2Error(responseBody: any): OAuth2AuthenticationError | null 
 
 export default function createContentgridTokenExchangeTokenSupplier(config: TokenExchangeConfiguration): AuthenticationTokenSupplier {
     return async (uri, opts) => {
-        const response = await config.fetch(config.exchangeUrl, {
+        const response = await opts.fetch(config.exchangeUrl, {
             signal: opts?.signal ?? null,
             method: "POST",
             body: createTokenRequestBody(uri)

--- a/packages/fetch-hook-authentication/src/token-supplier/index.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/index.ts
@@ -1,0 +1,3 @@
+export { default as createCompositeTokenSupplier, CompositeTokenSupplierBuilder } from "./composite"
+export { default as createContentgridTokenExchangeTokenSupplier, TokenExchangeProtocolViolationError, OAuth2AuthenticationError, TokenExchangeError } from "./contentgridTokenExchange";
+export type { AuthenticationTokenSupplier, AuthenticationToken } from "./types";

--- a/packages/fetch-hook-authentication/src/token-supplier/types.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/types.ts
@@ -6,7 +6,8 @@ export interface AuthenticationToken {
 
 
 interface AuthenticationTokenSupplierOptions {
-    signal?: AbortSignal
+    fetch: typeof fetch;
+    signal?: AbortSignal;
 }
 
-export type AuthenticationTokenSupplier = (uri: string, opts?: AuthenticationTokenSupplierOptions) => Promise<AuthenticationToken | null>;
+export type AuthenticationTokenSupplier = (uri: string, opts: AuthenticationTokenSupplierOptions) => Promise<AuthenticationToken | null>;

--- a/packages/fetch-hook-authentication/src/token-supplier/types.ts
+++ b/packages/fetch-hook-authentication/src/token-supplier/types.ts
@@ -1,0 +1,12 @@
+
+export interface AuthenticationToken {
+    token: string;
+    expiresAt: Date | null;
+}
+
+
+interface AuthenticationTokenSupplierOptions {
+    signal?: AbortSignal
+}
+
+export type AuthenticationTokenSupplier = (uri: string, opts?: AuthenticationTokenSupplierOptions) => Promise<AuthenticationToken | null>;

--- a/packages/fetch-hook-authentication/tsconfig.json
+++ b/packages/fetch-hook-authentication/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "extends": "../../config/tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "./src"
+    }
+}

--- a/packages/fetch-hooks/README.md
+++ b/packages/fetch-hooks/README.md
@@ -36,12 +36,21 @@ Next to the built-in hooks, it is also possible to create your own hooks.
 ```typescript
 import createFetchHook from "@contentgrid/fetch-hooks";
 
-const requireJsonHook = createFetchHook(({request, next}) => {
+const requireJsonHook = createFetchHook(({request, next, entrypoint}) => {
 
     // Do something fun with the request, before sending it off to the next hook
     // For example, setting an accept header when we have none
     if(!request.headers.has("accept")) {
         request.headers.set("accept", "application/json, application/*+json;q=0.9, */*;q=0.1")
+    }
+
+    // Send another request that will also pass through all hooks again.
+    // Be careful not to cause infinite loops!
+    if(request.url != "http://example.net/log_request") {
+        await entrypoint("http://example.net/log_request", {
+            method: "POST",
+            body: request.uri
+        });
     }
 
     const response = await next(); // Forward the modified request to the next hook

--- a/packages/fetch-hooks/src/hook/context.ts
+++ b/packages/fetch-hooks/src/hook/context.ts
@@ -1,0 +1,71 @@
+import { HookedFetch } from "./core";
+import { FetchHookInvocation } from "./invocation";
+
+export class RequestContext {
+    private constructor(
+        /**
+         * Initial entrypoint where the request entered the hook chain
+         */
+        public readonly entrypoint: HookedFetch,
+
+        /**
+         * Super invocation, the invocation that caused the re-entry into the hook chain via the entrypoint
+         */
+        public readonly superInvocation: FetchHookInvocation | null,
+        /**
+         * Super context, the context belonging to the invocation that caused re-entry into the hook chain via the entrypoint
+         */
+        public readonly superContext: RequestContext | null,
+    ) {
+
+    }
+
+    public static create(entrypoint: HookedFetch) {
+        return new RequestContext(entrypoint, null, null);
+    }
+
+    public withSuperInvocation(invocation: FetchHookInvocation) {
+        return new RequestContext(this.entrypoint, invocation, this);
+    }
+
+    /**
+     * Depth of recursive invocations of the hook chain
+     */
+    public get recursiveInvocationDepth(): number {
+        if(!this.superContext) {
+            return 0;
+        }
+        return this.superContext.recursiveInvocationDepth + 1;
+    }
+}
+
+const requestContextSymbol = Symbol("fetch-hooks: request context");
+
+export interface RequestInitWithContext extends RequestInit {
+    [requestContextSymbol]: RequestContext
+}
+
+export function enhanceRequestInitWithContext(init: RequestInit|undefined, context: RequestContext): RequestInitWithContext {
+    return {
+        ...(init ?? {}),
+        ...createRequestInitWithContext(context)
+    }
+}
+
+export function createRequestInitWithContext(context: RequestContext): RequestInitWithContext {
+    return {
+        [requestContextSymbol]: context
+    };
+}
+
+function hasContext(init: RequestInit): init is RequestInitWithContext {
+    return requestContextSymbol in init;
+}
+
+export function getRequestContext(...args: Parameters<HookedFetch>): RequestContext | null {
+    const init = args[1];
+    if(init && hasContext(init)) {
+        return init[requestContextSymbol];
+    }
+    return null;
+}

--- a/packages/fetch-hooks/src/request.ts
+++ b/packages/fetch-hooks/src/request.ts
@@ -1,10 +1,11 @@
-import { ValueProvider, resolveValueProvider } from "./value-provider";
+import { ValueProvider, ValueProviderResolver } from "./value-provider";
 
-import createHook, { FetchHook } from "./hook";
+import createHook, { FetchHook, ReadonlyFetchHookInvocation } from "./hook";
 
-export function appendHeader(headerName: string, value: ValueProvider<string | null>): FetchHook {
+export function appendHeader(headerName: string, value: ValueProvider<string | null, [ReadonlyFetchHookInvocation]>): FetchHook {
     return createHook(async (invocation) => {
-        const resolved = await resolveValueProvider(invocation, value);
+        const resolved = await ValueProviderResolver.fromValueProvider(value).resolve(invocation);
+
         if(resolved !== null) {
             invocation.request.headers.append(headerName, resolved);
         }
@@ -12,9 +13,9 @@ export function appendHeader(headerName: string, value: ValueProvider<string | n
     })
 }
 
-export function setHeader(headerName: string, value: ValueProvider<string | null>): FetchHook {
+export function setHeader(headerName: string, value: ValueProvider<string | null, [ReadonlyFetchHookInvocation]>): FetchHook {
     return createHook(async (invocation) => {
-        const resolved = await resolveValueProvider(invocation, value);
+        const resolved = await ValueProviderResolver.fromValueProvider(value).resolve(invocation);
         if(resolved !== null) {
             invocation.request.headers.set(headerName, resolved);
         }

--- a/packages/fetch-hooks/src/value-provider.ts
+++ b/packages/fetch-hooks/src/value-provider.ts
@@ -84,11 +84,11 @@ export namespace ValueProviderResolver {
 
     /**
      * Creates a cached {@link ValueProviderResolver}, where the initially resolved value is cached after it is requested once
-     * @param resolver Resolver to cache
+     * @param valueProvider The value provider to cache
      * @returns Resolver that automatically caches the first resolved value
      */
-    export function cached<T, Args extends readonly any[]>(resolver: ValueProviderResolver<T, Args>): ValueProviderResolver<T, Args> {
-        return new CachedValueProviderResolver(resolver);
+    export function cached<T, Args extends readonly any[]>(valueProvider: ValueProvider<T, Args>): ValueProviderResolver<T, Args> {
+        return new CachedValueProviderResolver(fromValueProvider(valueProvider));
     }
 
 }

--- a/packages/fetch-hooks/src/value-provider.ts
+++ b/packages/fetch-hooks/src/value-provider.ts
@@ -87,7 +87,7 @@ export namespace ValueProviderResolver {
      * @param resolver Resolver to cache
      * @returns Resolver that automatically caches the first resolved value
      */
-    export function cached<T>(resolver: ValueProviderResolver<T, []>): ValueProviderResolver<T, []> {
+    export function cached<T, Args extends readonly any[]>(resolver: ValueProviderResolver<T, Args>): ValueProviderResolver<T, Args> {
         return new CachedValueProviderResolver(resolver);
     }
 
@@ -121,20 +121,20 @@ class ConstantValueProviderResolver<T> implements ValueProviderResolver<T, reado
     }
 }
 
-class CachedValueProviderResolver<T> implements ValueProviderResolver<T, []> {
+class CachedValueProviderResolver<T, Args extends readonly any[]> implements ValueProviderResolver<T, Args> {
     public readonly [valueProviderResolver] = true as const;
 
     #cachedValue: Promise<T> | undefined;
 
     public constructor(
-        private readonly delegate: ValueProviderResolver<T, []>
+        private readonly delegate: ValueProviderResolver<T, Args>
     ) {
 
     }
 
-    public resolve(): Promise<T> {
+    public resolve(...args: Args): Promise<T> {
         if(!this.#cachedValue) {
-            this.#cachedValue = this.delegate.resolve();
+            this.#cachedValue = this.delegate.resolve(...args);
         }
 
         return this.#cachedValue;

--- a/packages/fetch-hooks/src/value-provider.ts
+++ b/packages/fetch-hooks/src/value-provider.ts
@@ -1,4 +1,3 @@
-import type { ReadonlyFetchHookInvocation } from "./hook";
 
 type NotFunction<T> = T extends Function ? never : T;
 
@@ -13,7 +12,10 @@ type MaybePromise<T> = T | Promise<T>;
  *  - derived from the invocation synchronously
  *  - derived from the invocation asynchronously (potentially making another async request to fetch the value)
  */
-export type ValueProvider<T> = MaybePromise<NotFunction<T>> | ((invocation: ReadonlyFetchHookInvocation) => MaybePromise<NotFunction<T>>);
+export type ValueProvider<T, Args extends readonly any[]> =
+    MaybePromise<NotFunction<T>> |
+    ((...args: Args) => MaybePromise<T>) |
+    ValueProviderResolver<T, Args>;
 
 /**
  * Resolves a {@link ValueProvider} to its value
@@ -22,11 +24,119 @@ export type ValueProvider<T> = MaybePromise<NotFunction<T>> | ((invocation: Read
  * @param fetch - Fetch function
  * @param valueProvider - The value provider to resolve
  * @returns The value of the value provider
+ * @deprecated Use {@link ValueProviderResolver} instead
  */
-export function resolveValueProvider<T>(invocation: ReadonlyFetchHookInvocation, valueProvider: ValueProvider<NotFunction<T>>): Promise<NotFunction<T>> {
-    if (valueProvider instanceof Function) {
-        return Promise.resolve(valueProvider(invocation));
-    } else {
-        return Promise.resolve(valueProvider);
+export function resolveValueProvider<T, Args extends readonly any[]>(args: Args, valueProvider: ValueProvider<NotFunction<T>, Args>): Promise<NotFunction<T>> {
+    return ValueProviderResolver.fromValueProvider(valueProvider).resolve(...args);
+}
+
+const valueProviderResolver = Symbol("ValueProviderResolver: instance");
+
+/**
+ * Resolves a {@link ValueProvider} to its value
+ */
+export interface ValueProviderResolver<T, Args extends readonly any[]> {
+    /**
+     * Marks that this is a {@link ValueProviderResolver}, to distinguish it from other objects
+     */
+    readonly [valueProviderResolver]: true;
+    /**
+     * Resolves the value
+     * @param args arguments to resolve the value
+     */
+    resolve(...args: Args): Promise<T>;
+};
+
+export namespace ValueProviderResolver {
+    /**
+     * Creates a function-backed {@link ValueProviderResolver}
+     * @param func Function to call to obtain a value
+     */
+    export function fn<T, Args extends readonly any[]>(func: (...args: Args) => T): ValueProviderResolver<T, Args> {
+        return new FunctionValueProviderResolver(func);
+    }
+
+    /**
+     * Creates a constant-based {@link ValueProviderResolver}
+     * @param constant The value
+     */
+    export function constant<T>(constant: MaybePromise<T>): ValueProviderResolver<T, readonly any[]> {
+        return new ConstantValueProviderResolver(constant);
+    }
+
+    function isValueProviderResolver(object: object | null): object is ValueProviderResolver<any, any> {
+        return object !== null && valueProviderResolver in object;
+    }
+
+    /**
+     * Creates a {@link ValueProviderResolver} from a {@link ValueProvider} of an unknown type
+     * @param valueProvider The value provider to convert to a resolver
+     */
+    export function fromValueProvider<T, Args extends readonly any[]>(valueProvider: ValueProvider<T, Args>): ValueProviderResolver<T, Args> {
+        if(typeof valueProvider === "object" && isValueProviderResolver(valueProvider)) {
+            return valueProvider;
+        } else if(valueProvider instanceof Function) {
+            return fn<T, Args>(valueProvider as any);
+        } else {
+            return constant(valueProvider);
+        }
+    }
+
+    /**
+     * Creates a cached {@link ValueProviderResolver}, where the initially resolved value is cached after it is requested once
+     * @param resolver Resolver to cache
+     * @returns Resolver that automatically caches the first resolved value
+     */
+    export function cached<T>(resolver: ValueProviderResolver<T, []>): ValueProviderResolver<T, []> {
+        return new CachedValueProviderResolver(resolver);
+    }
+
+}
+
+class FunctionValueProviderResolver<T, Args extends readonly any[]> implements ValueProviderResolver<T, Args> {
+    public readonly [valueProviderResolver] = true as const;
+
+    public constructor(
+        private readonly func: (...args: Args) => MaybePromise<T>
+    ) {
+
+    }
+
+    public async resolve(...args: Args): Promise<T> {
+        return this.func(...args);
+    }
+}
+
+class ConstantValueProviderResolver<T> implements ValueProviderResolver<T, readonly any[]> {
+    public readonly [valueProviderResolver] = true as const;
+
+    public constructor(
+        private readonly constant: MaybePromise<T>
+    ) {
+
+    }
+
+    public async resolve() {
+        return this.constant;
+    }
+}
+
+class CachedValueProviderResolver<T> implements ValueProviderResolver<T, []> {
+    public readonly [valueProviderResolver] = true as const;
+
+    #cachedValue: Promise<T> | undefined;
+
+    public constructor(
+        private readonly delegate: ValueProviderResolver<T, []>
+    ) {
+
+    }
+
+    public resolve(): Promise<T> {
+        if(!this.#cachedValue) {
+            this.#cachedValue = this.delegate.resolve();
+        }
+
+        return this.#cachedValue;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,6 +2122,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^29.5.12":
+  version "29.5.12"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.12.tgz#7f7dc6eb4cf246d2474ed78744b05d06ce025544"
+  integrity sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==
+  dependencies:
+    expect "^29.0.0"
+    pretty-format "^29.0.0"
+
 "@types/minimatch@^3.0.3":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
@@ -2153,6 +2161,11 @@
   version "0.1.34"
   resolved "https://registry.yarnpkg.com/@types/uri-templates/-/uri-templates-0.1.34.tgz#be9b6fb7d205c641e4bf1c46776f84e9b26ad631"
   integrity sha512-13v4r/Op3iEO1y6FvEHQjrUNnrNyO67SigdFC9n80sVfsrM2AWJRNYbE1pBs4/p87I7z1J979JGeLAo3rM1L/Q==
+
+"@types/whatwg-mimetype@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz#e5e06dcd3e92d4e622ef0129637707d66c28d6a4"
+  integrity sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -3162,7 +3175,7 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==
 
-expect@^29.7.0:
+expect@^29.0.0, expect@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-29.7.0.tgz#578874590dcb3214514084c08115d8aee61e11bc"
   integrity sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==
@@ -4010,7 +4023,7 @@ jest-config@^29.7.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-"jest-diff@>=29.4.3 < 30", jest-diff@^29.4.1, jest-diff@^29.7.0:
+"jest-diff@>=29.4.3 < 30", jest-diff@^29.0.0, jest-diff@^29.4.1, jest-diff@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
   integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
@@ -4050,7 +4063,15 @@ jest-environment-node@^29.7.0:
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
 
-jest-get-type@^29.6.3:
+jest-extended@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-4.0.2.tgz#d23b52e687cedf66694e6b2d77f65e211e99e021"
+  integrity sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==
+  dependencies:
+    jest-diff "^29.0.0"
+    jest-get-type "^29.0.0"
+
+jest-get-type@^29.0.0, jest-get-type@^29.6.3:
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
   integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
@@ -5426,7 +5447,7 @@ postcss-selector-parser@^6.0.10:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-pretty-format@^29.7.0:
+pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
@@ -6439,6 +6460,11 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
 whatwg-url@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Add functionality to provide custom bearer authentication tokens for different URLs that are fetched

There is a custom token supplier implementation that performs a contentgrid token exchange to exchange a
standard user token to a limited external authentication token
