### PR TITLE
[ACC-1682] Add HalFormsTemplateBuilder#fromTemplate method

### DIFF
--- a/packages/hal-forms/__tests__/builder.ts
+++ b/packages/hal-forms/__tests__/builder.ts
@@ -1,0 +1,16 @@
+import buildTemplate, { HalFormsTemplateBuilder } from "../src/builder";
+
+describe("HalFormsTemplateBuilder", () => {
+    it("#fromTemplate", () => {
+        const original = buildTemplate("GET", "/")
+            .withContentType("application/json")
+            .addProperty("xyz", p => p.withPrompt("Test"));
+
+        const fromTemplate = HalFormsTemplateBuilder.fromTemplate(original);
+
+        expect(fromTemplate.contentType).toEqual("application/json");
+        expect(fromTemplate.properties).toHaveLength(1);
+        expect(fromTemplate.properties[0]?.name).toEqual("xyz");
+        expect(fromTemplate.properties[0]?.prompt).toEqual("Test");
+    })
+});

--- a/packages/hal-forms/src/builder.ts
+++ b/packages/hal-forms/src/builder.ts
@@ -19,6 +19,18 @@ export class HalFormsTemplateBuilder<Body, Response> implements HalFormsTemplate
         return new HalFormsTemplateBuilder(request.method + " "+request.url, request);
     }
 
+    public static fromTemplate<B, R>(template: HalFormsTemplate<TypedRequestSpec<B, R>>): HalFormsTemplateBuilder<B, R> {
+        let builder = this.from(template.request)
+            .withName(template.name)
+            .withContentType(template.contentType);
+
+        for (const prop of template.properties) {
+            builder = builder.addProperty(prop.name, () => prop);
+        }
+
+        return builder;
+    }
+
     public get title() {
         return undefined;
     }


### PR DESCRIPTION
Add ability to easily create a builder from an existing hal forms template,
to modify the template when it's necessary
