### PR TITLE
Fix imports to always import files (instead of bare '..')

### DIFF
--- a/packages/hal-forms/src/codecs/coders/json.ts
+++ b/packages/hal-forms/src/codecs/coders/json.ts
@@ -3,7 +3,7 @@ import { HalFormsProperty, HalFormsTemplate } from "../../api";
 import { EncodedHalFormsRepresentation, HalFormsDecoder, HalFormsEncoder } from "./api";
 import { HalFormsPropertyType } from "../../_shape";
 import { createValues, AnyHalFormValue, HalFormValues } from "../../values";
-import { HalFormsDecoderRepresentationNotSupportedError } from "..";
+import { HalFormsDecoderRepresentationNotSupportedError } from "../errors";
 
 /**
  * Encodes HAL-FORMS values as a JSON object

--- a/packages/hal-forms/src/codecs/coders/uri-list.ts
+++ b/packages/hal-forms/src/codecs/coders/uri-list.ts
@@ -1,5 +1,5 @@
 import { TypedRequestSpec, TypedRequest, createRequest, Representation } from "@contentgrid/typed-fetch";
-import { HalFormsProperty, HalFormsTemplate } from "../..";
+import { HalFormsProperty, HalFormsTemplate } from "../../index";
 import { AnyHalFormValue } from "../../values";
 import { HalFormsEncoder } from "./api";
 import { HalFormsPropertyType } from "../../_shape";

--- a/packages/hal-forms/src/codecs/errors.ts
+++ b/packages/hal-forms/src/codecs/errors.ts
@@ -1,5 +1,5 @@
 import { HalError } from "@contentgrid/hal";
-import { HalFormsTemplateError, HalFormsTemplate, HalFormsTemplatePropertyError, HalFormsProperty } from "..";
+import { HalFormsTemplateError, HalFormsTemplate, HalFormsTemplatePropertyError, HalFormsProperty } from "../index";
 import { EncodedHalFormsRepresentation } from "./coders";
 
 /**

--- a/packages/hal-forms/src/codecs/impl.ts
+++ b/packages/hal-forms/src/codecs/impl.ts
@@ -1,5 +1,5 @@
 import { TypedRequest, TypedRequestSpec } from "@contentgrid/typed-fetch";
-import { HalFormsTemplate } from "..";
+import { HalFormsTemplate } from "../index";
 import { HalFormsCodec, HalFormsEncoderMatcher, HalFormsCodecs, HalFormsCodecsBuilder, HalFormsEncoderMatchers, HalFormsDecoderMatcher, HalFormsDecoderMatchers } from "./api";
 import { EncodedHalFormsRepresentation, HalFormsDecoder, HalFormsEncoder } from "./coders/api";
 import { HalFormsCodecNotAvailableError, HalFormsCodecPropertyTypeNotSupportedError, HalFormsDecoderNotAvailableError, HalFormsDecoderRepresentationNotSupportedError, HalFormsEncoderNotAvailableError } from "./errors";


### PR DESCRIPTION
Having just a bare '..' to import is not transformed to a file import by
vite. This results in errors when using the modules in some
constellations when using ESM.

> ERROR in ./node_modules/@contentgrid/hal-forms/build/codecs/coders/json.mjs 4:0-68
> Module not found: Error: Can't resolve '..' in './node_modules/@contentgrid/hal-forms/build/codecs/coders'
> Did you mean 'index.mjs'?
> BREAKING CHANGE: The request '..' failed to resolve only because it was resolved as fully specified
> (probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
> The extension in the request is mandatory for it to be fully specified.
> Add the extension to the request.
